### PR TITLE
Fix link avatar trong trang admin chuyển hướng ko đúng + Logo ở user-about bị mất do revert

### DIFF
--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -10,6 +10,7 @@ import webauthn
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
+from django.core.files.storage import FileSystemStorage
 from django.db import models
 from django.db.models import F, Max, Sum
 from django.forms import forms
@@ -156,10 +157,16 @@ class Badge(models.Model):
         return self.name
 
 
+class MediaPrefixedStorage(FileSystemStorage):
+    def url(self, name):
+        return f"/media/{name}"
+
+
 class Logo(models.Model):
     name = models.CharField(max_length=128, verbose_name=_('logo name'))
     image = ContentTypeRestrictedFileField(upload_to='logo/', content_types=['image/*'],
-                                           null=True, verbose_name='logo file')
+                                           null=True, verbose_name=_('logo file'),
+                                           storage=MediaPrefixedStorage())
 
     def __str__(self):
         return self.name

--- a/judge/models/profile.py
+++ b/judge/models/profile.py
@@ -9,8 +9,8 @@ import pyotp
 import webauthn
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.validators import RegexValidator
 from django.core.files.storage import FileSystemStorage
+from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import F, Max, Sum
 from django.forms import forms
@@ -159,7 +159,7 @@ class Badge(models.Model):
 
 class MediaPrefixedStorage(FileSystemStorage):
     def url(self, name):
-        return f"/media/{name}"
+        return f'/media/{name}'
 
 
 class Logo(models.Model):

--- a/templates/user/base-users-table-contest.html
+++ b/templates/user/base-users-table-contest.html
@@ -39,11 +39,11 @@
                             {% if user.avt_url %}
                                 <img id="avatarPreview" src="/media/{{ user.avt_url }}">
                             {% else %}
-                                <div id="avatarPlaceholder"><i class="fa fa-user"></i></div>
+                                <img id="avatarPreview" src="{{ gravatar(user.user, 64) }}">
                             {% endif %}
                         {% elif contest.rank_display_options == 2 %}
                             {% if user.user_rank_logo and user.user_rank_logo.image.url %}
-                                <img id="avatarPreview" src="/media{{ user.user_rank_logo.image.url }}">
+                                <img id="avatarPreview" src="{{ user.user_rank_logo.image.url }}">
                             {% else %}
                                 <div id="avatarPlaceholder"><i class="fa fa-graduation-cap"></i></div>
                             {% endif %}

--- a/templates/user/edit-profile.html
+++ b/templates/user/edit-profile.html
@@ -291,11 +291,17 @@
                         {% if form.display_badge %}
                             <td><div class="block-header grayed">{{ _('Display badge') }}:</div></td>
                         {% endif %}
+                        {% if form.user_rank_logo %}
+                            <td><div class="block-header grayed">Logo:</div></td>
+                        {% endif %}
                     </tr>
                     <tr>
                         <td>{{ form_user.first_name }}</td>
                         {% if form.display_badge %}
                             <td>{{ form.display_badge }}</td>
+                        {% endif %}
+                        {% if form.user_rank_logo %}
+                            <td>{{ form.user_rank_logo }}</td>
                         {% endif %}
                     </tr>
                 </table>

--- a/templates/user/user-about.html
+++ b/templates/user/user-about.html
@@ -44,7 +44,19 @@
             </i>
             <br>
         {% endif %}
-
+        {% if user.user_rank_logo and user.user_rank_logo.image.url %}
+            <h4>Logo</h4>
+            <div class="u-logo-container">
+                <div class="u-logo-frag">
+                    <img src="{{ user.user_rank_logo.image.url }}" title="{{ user.user_rank_logo.name }}" />
+                </div>
+                <div class="u-logo-name-wrapper">
+                    <p>{{ user.user_rank_logo.name }}</p>
+                </div>
+            </div>
+        {% else %}
+            <h4>Người dùng chưa đặt Logo</h4>
+        {% endif %}
         <h4>{{ _('Badges & Awards') }}</h4>
         {% for badge in user.badges.all() %}
             <div style="display: inline-block; margin-left: 1em; margin-right: 1em;">


### PR DESCRIPTION
# Mô tả
- Fix link avatar trong trang admin chuyển hướng ko đúng
- Logo ở user-about bị mất do revert

**Bằng cách đặt url lưu mặc định là _/media/logo/..._ thay vì _/logo/..._**

# Lưu ý
**PR này bao gồm bản fix link của @ThisIsNotNam ([Ở đây](https://github.com/ThisIsNotNam/oj/commit/0ba7229cb0810b009cfc8a62225e716bfda13ec3)) + Bản fix hiển thị logo ở user-about do revert + Đổi Placeholder khi không có avatar người dùng trong bảng rank**