### PR TITLE
feat: redesign spotlight ranking with ICPC-style resolver

### DIFF
--- a/judge/management/commands/seed_resolver_demo.py
+++ b/judge/management/commands/seed_resolver_demo.py
@@ -1,0 +1,486 @@
+from django.conf import settings
+from django.contrib.auth.models import Permission, User
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.urls import reverse
+from django.utils import timezone
+
+from judge.models import Contest, ContestParticipation, ContestProblem, ContestSubmission, Language, Problem, \
+    ProblemGroup, ProblemType, Profile, Submission
+from judge.resolver import build_resolver_payload
+
+
+DEMO_MARKER = '[CHTOJ resolver demo v1]'
+DIRECTOR_USERNAME = 'resolver_director'
+DEFAULT_DIRECTOR_PASSWORD = 'resolver-demo'
+
+DEMO_USERS = (
+    ('resolver_ada', 'Ada Nguyen'),
+    ('resolver_bruno', 'Bruno Tran'),
+    ('resolver_chen', 'Chen Le'),
+    ('resolver_daria', 'Daria Pham'),
+    ('resolver_elena', 'Elena Vo'),
+    ('resolver_farid', 'Farid Hoang'),
+    ('resolver_gia', 'Gia Bui'),
+    ('resolver_hugo', 'Hugo Do'),
+)
+
+PROBLEM_NAMES = (
+    'Array Relay',
+    'Bridge Signals',
+    'Clockwork Graph',
+    'Delta Delivery',
+    'Echoes in the Grid',
+)
+
+
+CONTEST_BLUEPRINTS = {
+    'default': {
+        'key': 'resolver_demo_default',
+        'name': 'Resolver Demo — Default Sprint',
+        'format_config': None,
+        'frozen_last_minutes': 0,
+        'problem_points': 100,
+        'submissions': (
+            ('resolver_ada', 0, 20, 40),
+            ('resolver_ada', 0, 60, 100),
+            # Default format deliberately uses the last submission time independently of maximum points.
+            ('resolver_ada', 0, 200, 0),
+            ('resolver_ada', 1, 120, 75),
+            ('resolver_ada', 2, 260, 50),
+            ('resolver_bruno', 0, 50, 100),
+            ('resolver_bruno', 1, 100, 100),
+            ('resolver_bruno', 2, 150, 50),
+            ('resolver_bruno', 3, 200, 0),
+            ('resolver_chen', 0, 30, 100),
+            ('resolver_chen', 1, 90, 100),
+            ('resolver_chen', 2, 180, 50),
+            ('resolver_daria', 0, 30, 100),
+            ('resolver_daria', 1, 90, 100),
+            ('resolver_daria', 2, 180, 50),
+            ('resolver_daria', 3, 250, 0),
+            ('resolver_elena', 0, 70, 100),
+            ('resolver_elena', 1, 140, 50),
+            ('resolver_elena', 2, 210, 50),
+            ('resolver_elena', 3, 270, 50),
+            ('resolver_farid', 0, 120, 50),
+            ('resolver_farid', 1, 240, 50),
+            ('resolver_gia', 0, 80, 0),
+            ('resolver_gia', 2, 220, 0),
+            ('resolver_hugo', 0, 25, 100),
+            ('resolver_hugo', 1, 80, 100),
+            ('resolver_hugo', 2, 130, 100),
+            ('resolver_hugo', 3, 190, 100),
+        ),
+        'disqualified': ('resolver_hugo',),
+    },
+    'icpc': {
+        'key': 'resolver_demo_icpc',
+        'name': 'Resolver Demo — ICPC Championship',
+        'format_config': {'penalty': 20},
+        'frozen_last_minutes': 60,
+        'problem_points': 1,
+        'submissions': (
+            ('resolver_ada', 0, 12, 1),
+            ('resolver_ada', 1, 35, 0),
+            ('resolver_ada', 1, 50, 1),
+            ('resolver_ada', 2, 100, 1),
+            ('resolver_ada', 3, 245, 0),
+            ('resolver_ada', 3, 270, 1),
+            ('resolver_bruno', 0, 15, 0),
+            ('resolver_bruno', 0, 30, 1),
+            ('resolver_bruno', 1, 75, 1),
+            ('resolver_bruno', 2, 200, 0),
+            ('resolver_bruno', 2, 250, 1),
+            ('resolver_bruno', 3, 260, 0),
+            ('resolver_chen', 0, 25, 1),
+            ('resolver_chen', 1, 70, 1),
+            ('resolver_chen', 2, 110, 1),
+            ('resolver_chen', 3, 150, 1),
+            ('resolver_chen', 4, 235, 1),
+            ('resolver_daria', 0, 10, 0),
+            ('resolver_daria', 0, 40, 1),
+            ('resolver_daria', 1, 20, 0),
+            ('resolver_daria', 1, 60, 0),
+            ('resolver_daria', 1, 90, 1),
+            ('resolver_daria', 2, 130, 1),
+            ('resolver_daria', 3, 180, 1),
+            ('resolver_daria', 4, 250, 0),
+            ('resolver_daria', 4, 290, 1),
+            # Elena has the same official score keys as Chen but one extra, post-AC submission.
+            ('resolver_elena', 0, 25, 1),
+            ('resolver_elena', 1, 70, 1),
+            ('resolver_elena', 2, 110, 1),
+            ('resolver_elena', 3, 150, 1),
+            ('resolver_elena', 4, 235, 1),
+            ('resolver_elena', 4, 260, 0),
+            ('resolver_farid', 0, 45, 1),
+            ('resolver_farid', 1, 100, 0),
+            ('resolver_farid', 2, 210, 1),
+            ('resolver_farid', 4, 242, 0),
+            ('resolver_gia', 0, 60, 0),
+            ('resolver_gia', 1, 180, 0),
+            ('resolver_gia', 2, 245, 0),
+            ('resolver_gia', 3, 270, 0),
+            ('resolver_hugo', 0, 20, 1),
+            ('resolver_hugo', 1, 40, 1),
+            ('resolver_hugo', 2, 70, 1),
+            ('resolver_hugo', 3, 250, 1),
+        ),
+        'disqualified': ('resolver_hugo',),
+    },
+    'vnoj': {
+        'key': 'resolver_demo_vnoj',
+        'name': 'Resolver Demo — VNOJ Open',
+        'format_config': {'penalty': 5, 'LSO': False},
+        'frozen_last_minutes': 60,
+        'problem_points': 100,
+        'submissions': (
+            ('resolver_ada', 0, 25, 100),
+            ('resolver_ada', 1, 90, 40),
+            ('resolver_ada', 1, 255, 100),
+            ('resolver_ada', 2, 180, 60),
+            ('resolver_ada', 3, 270, 0),
+            ('resolver_bruno', 0, 20, 0),
+            ('resolver_bruno', 0, 50, 100),
+            ('resolver_bruno', 1, 130, 100),
+            ('resolver_bruno', 2, 230, 100),
+            # A full score before freeze suppresses this cell's pending presentation.
+            ('resolver_bruno', 0, 260, 0),
+            ('resolver_chen', 0, 80, 80),
+            ('resolver_chen', 0, 250, 100),
+            ('resolver_chen', 1, 120, 100),
+            ('resolver_chen', 2, 200, 50),
+            ('resolver_chen', 3, 238, 100),
+            ('resolver_daria', 0, 30, 0),
+            ('resolver_daria', 0, 60, 100),
+            ('resolver_daria', 1, 100, 50),
+            ('resolver_daria', 1, 200, 100),
+            ('resolver_daria', 2, 220, 100),
+            ('resolver_daria', 3, 250, 0),
+            ('resolver_daria', 3, 280, 100),
+            ('resolver_elena', 0, 40, 100),
+            ('resolver_elena', 1, 140, 80),
+            ('resolver_elena', 2, 190, 80),
+            ('resolver_elena', 3, 230, 80),
+            ('resolver_elena', 4, 239, 100),
+            ('resolver_elena', 4, 270, 0),
+            ('resolver_farid', 0, 100, 50),
+            ('resolver_farid', 1, 150, 50),
+            ('resolver_farid', 2, 200, 50),
+            ('resolver_farid', 3, 250, 50),
+            # Zero-point attempts remain visible but add no aggregate VNOJ penalty.
+            ('resolver_gia', 0, 50, 0),
+            ('resolver_gia', 1, 100, 0),
+            ('resolver_gia', 2, 245, 0),
+            ('resolver_gia', 3, 260, 0),
+            ('resolver_hugo', 0, 20, 100),
+            ('resolver_hugo', 1, 40, 100),
+            ('resolver_hugo', 2, 60, 100),
+        ),
+        'disqualified': ('resolver_hugo',),
+    },
+}
+
+
+class Command(BaseCommand):
+    help = 'Seed local ended contests with realistic submissions for Resolver development.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--format',
+            choices=('all', 'default', 'icpc', 'vnoj'),
+            default='all',
+            help='Resolver format to seed (default: all).',
+        )
+        parser.add_argument(
+            '--replace',
+            action='store_true',
+            help='Replace only contests previously created by this command.',
+        )
+        parser.add_argument(
+            '--director-password',
+            default=DEFAULT_DIRECTOR_PASSWORD,
+            help='Password for the local resolver_director account.',
+        )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError('seed_resolver_demo is local development data and requires DEBUG=True.')
+
+        selected_formats = tuple(CONTEST_BLUEPRINTS) if options['format'] == 'all' else (options['format'],)
+        language = self._get_language()
+
+        with transaction.atomic():
+            director = self._ensure_director(language, options['director_password'])
+            profiles = self._ensure_contestants(language)
+            problem_group, problem_type = self._ensure_problem_metadata()
+            contests = []
+
+            for format_name in selected_formats:
+                blueprint = CONTEST_BLUEPRINTS[format_name]
+                contest = Contest.objects.filter(key=blueprint['key']).first()
+                if contest is not None:
+                    self._assert_owned_contest(contest)
+                    if options['replace']:
+                        self._delete_contest_data(contest)
+                    else:
+                        contests.append(contest)
+                        self.stdout.write(
+                            'Kept existing %s; pass --replace to rebuild it.' % contest.key,
+                        )
+                        continue
+
+                contest = self._create_contest(
+                    format_name,
+                    blueprint,
+                    director.profile,
+                    profiles,
+                    language,
+                    problem_group,
+                    problem_type,
+                )
+                contests.append(contest)
+
+        self.stdout.write('')
+        self.stdout.write(self.style.SUCCESS('Resolver demo data is ready.'))
+        self.stdout.write('Director login: %s / %s' % (DIRECTOR_USERNAME, options['director_password']))
+        self.stdout.write('Contestant accounts have unusable passwords and exist only as ranking data.')
+        for contest in contests:
+            self._write_contest_summary(contest)
+
+    def _get_language(self):
+        language = Language.objects.filter(key=settings.DEFAULT_USER_LANGUAGE).first()
+        if language is None:
+            language = Language.objects.order_by('id').first()
+        if language is None:
+            raise CommandError('No submission language exists. Load a language fixture before seeding demo data.')
+        return language
+
+    def _ensure_director(self, language, password):
+        user = User.objects.filter(username=DIRECTOR_USERNAME).first()
+        created = user is None
+        if created:
+            user = User(username=DIRECTOR_USERNAME, is_active=True, is_staff=True)
+        else:
+            self._assert_owned_user(user)
+
+        user.first_name = 'Resolver'
+        user.last_name = 'Director'
+        user.is_active = True
+        user.is_staff = True
+        user.set_password(password)
+        user.save()
+
+        profile, _ = Profile.objects.get_or_create(user=user, defaults={'language': language})
+        profile.about = '%s Local ceremony operator.' % DEMO_MARKER
+        profile.username_display_override = 'Resolver Director'
+        profile.save(update_fields=['about', 'username_display_override'])
+
+        permission = Permission.objects.filter(
+            content_type__app_label='judge',
+            codename='edit_own_contest',
+        ).first()
+        if permission is None:
+            raise CommandError('The judge.edit_own_contest permission is missing.')
+        user.user_permissions.add(permission)
+        return user
+
+    def _ensure_contestants(self, language):
+        profiles = {}
+        for username, display_name in DEMO_USERS:
+            user = User.objects.filter(username=username).first()
+            if user is None:
+                user = User(username=username, is_active=True)
+                user.set_unusable_password()
+                user.save()
+            else:
+                self._assert_owned_user(user)
+
+            profile, _ = Profile.objects.get_or_create(user=user, defaults={'language': language})
+            profile.about = '%s Generated contestant.' % DEMO_MARKER
+            profile.username_display_override = display_name
+            profile.save(update_fields=['about', 'username_display_override'])
+            profiles[username] = profile
+        return profiles
+
+    def _assert_owned_user(self, user):
+        try:
+            about = user.profile.about or ''
+        except Profile.DoesNotExist:
+            about = ''
+        if DEMO_MARKER not in about:
+            raise CommandError(
+                'Refusing to modify existing non-demo user %s.' % user.username,
+            )
+
+    def _ensure_problem_metadata(self):
+        problem_group, _ = ProblemGroup.objects.get_or_create(
+            name='resolver_demo',
+            defaults={'full_name': 'Resolver demo problems'},
+        )
+        problem_type, _ = ProblemType.objects.get_or_create(
+            name='resolver-demo',
+            defaults={'full_name': 'Resolver demo'},
+        )
+        return problem_group, problem_type
+
+    def _assert_owned_contest(self, contest):
+        if DEMO_MARKER not in (contest.summary or ''):
+            raise CommandError(
+                'Refusing to replace existing non-demo contest %s.' % contest.key,
+            )
+
+    def _delete_contest_data(self, contest):
+        submission_ids = list(
+            ContestSubmission.objects.filter(participation__contest=contest)
+            .values_list('submission_id', flat=True),
+        )
+        if submission_ids:
+            Submission.objects.filter(id__in=submission_ids).delete()
+        contest.delete()
+
+    def _create_contest(self, format_name, blueprint, director, profiles, language, problem_group, problem_type):
+        now = timezone.now().replace(second=0, microsecond=0)
+        end_time = now - timezone.timedelta(days=1)
+        start_time = end_time - timezone.timedelta(hours=5)
+        contest = Contest.objects.create(
+            key=blueprint['key'],
+            name=blueprint['name'],
+            description=(
+                '%s\n\nGenerated ended contest for Resolver development. '
+                'Its rows include partial scores, exact ties, failed attempts, freeze activity, and disqualification.'
+            ) % DEMO_MARKER,
+            summary='%s Safe local test data.' % DEMO_MARKER,
+            start_time=start_time,
+            end_time=end_time,
+            is_visible=True,
+            is_rated=False,
+            scoreboard_visibility=Contest.SCOREBOARD_VISIBLE,
+            show_submission_list=True,
+            format_name=format_name,
+            format_config=blueprint['format_config'],
+            frozen_last_minutes=blueprint['frozen_last_minutes'],
+            points_precision=0,
+            allow_spotlight=True,
+            locked_after=end_time,
+        )
+        contest.authors.add(director)
+
+        contest_problems = []
+        for index, problem_name in enumerate(PROBLEM_NAMES):
+            code = 'resdemo_%s_%s' % (format_name, chr(ord('a') + index))
+            problem = Problem.objects.filter(code=code).first()
+            if problem is None:
+                problem = Problem.objects.create(
+                    code=code,
+                    name='[Resolver Demo] %s' % problem_name,
+                    description=(
+                        '%s\n\nSynthetic problem used only to provide realistic local Resolver ranking data.'
+                    ) % DEMO_MARKER,
+                    source=DEMO_MARKER,
+                    group=problem_group,
+                    time_limit=2,
+                    memory_limit=65536,
+                    points=100,
+                    partial=True,
+                    is_public=True,
+                    is_manually_managed=True,
+                )
+                problem.types.add(problem_type)
+                problem.allowed_languages.add(language)
+                problem.authors.add(director)
+            elif DEMO_MARKER not in (problem.source or ''):
+                raise CommandError('Refusing to reuse existing non-demo problem %s.' % code)
+
+            contest_problems.append(ContestProblem.objects.create(
+                problem=problem,
+                contest=contest,
+                points=blueprint['problem_points'],
+                partial=format_name != 'icpc',
+                order=(index + 1) * 10,
+            ))
+
+        participations = {}
+        for username, _display_name in DEMO_USERS:
+            participations[username] = ContestParticipation.objects.create(
+                contest=contest,
+                user=profiles[username],
+                real_start=start_time,
+                virtual=ContestParticipation.LIVE,
+            )
+
+        for sequence, (username, problem_index, minute, points) in enumerate(blueprint['submissions'], 1):
+            self._create_submission(
+                participation=participations[username],
+                contest_problem=contest_problems[problem_index],
+                language=language,
+                submitted_at=start_time + timezone.timedelta(minutes=minute),
+                points=points,
+                sequence=sequence,
+            )
+
+        disqualified = set(blueprint['disqualified'])
+        for username, participation in participations.items():
+            participation.is_disqualified = username in disqualified
+            participation.save(update_fields=['is_disqualified'])
+            participation.recompute_results()
+
+        contest.update_user_count()
+        self._validate_contest(contest, blueprint)
+        return contest
+
+    def _create_submission(self, participation, contest_problem, language, submitted_at, points, sequence):
+        max_points = contest_problem.points
+        result = 'AC' if points == max_points else 'WA'
+        submission = Submission.objects.create(
+            user=participation.user,
+            problem=contest_problem.problem,
+            time=round(0.02 + (sequence % 9) * 0.013, 3),
+            memory=1024 + sequence * 8,
+            points=points,
+            language=language,
+            status='D',
+            result=result,
+            case_points=points,
+            case_total=max_points,
+            judged_date=submitted_at + timezone.timedelta(seconds=5),
+            locked_after=participation.contest.end_time,
+        )
+        Submission.objects.filter(pk=submission.pk).update(date=submitted_at)
+        ContestSubmission.objects.create(
+            submission=submission,
+            problem=contest_problem,
+            participation=participation,
+            points=points,
+        )
+
+    def _validate_contest(self, contest, blueprint):
+        payload = build_resolver_payload(contest)
+        if not contest.ended:
+            raise CommandError('Generated contest %s did not end in the past.' % contest.key)
+        if len(payload['contestants']) != len(DEMO_USERS):
+            raise CommandError('Generated contest %s has an incomplete field.' % contest.key)
+        if ContestSubmission.objects.filter(participation__contest=contest).count() != len(blueprint['submissions']):
+            raise CommandError('Generated contest %s has an incomplete submission history.' % contest.key)
+        if any(participation.format_data is None for participation in contest.users.all()):
+            raise CommandError('Generated contest %s was not recomputed.' % contest.key)
+
+        if contest.frozen_last_minutes:
+            pending = any(
+                cell['frozen'] and cell['frozen'].get('pending')
+                for contestant in payload['contestants']
+                for cell in contestant['problems'].values()
+            )
+            if not pending:
+                raise CommandError('Generated contest %s has no post-freeze cells.' % contest.key)
+
+    def _write_contest_summary(self, contest):
+        ranking_url = reverse('contest_ranking', args=(contest.key,))
+        resolver_url = reverse('spotlight_ranking', args=(contest.key,))
+        submission_count = ContestSubmission.objects.filter(participation__contest=contest).count()
+        self.stdout.write('')
+        self.stdout.write('%s (%s)' % (contest.name, contest.format_name))
+        self.stdout.write('  %d contestants, %d submissions' % (contest.user_count, submission_count))
+        self.stdout.write('  Ranking:  %s' % ranking_url)
+        self.stdout.write('  Resolver: %s' % resolver_url)

--- a/judge/models/tests/test_resolver.py
+++ b/judge/models/tests/test_resolver.py
@@ -1,0 +1,243 @@
+from pathlib import Path
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import resolve, reverse
+from django.utils import timezone
+
+from judge.models import Contest, ContestParticipation
+from judge.models.tests.util import create_contest_participation, create_contest_problem, create_problem, create_user
+from judge.resolver import ResolverUnsupportedFormat, build_resolver_payload
+from judge.views.contests import SpotlightContestRanking
+
+
+@override_settings(MOSS_API_KEY=None)
+class ResolverPayloadTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.editor = create_user(
+            username='resolver-editor',
+            is_staff=True,
+            user_permissions=('edit_own_contest',),
+        )
+        cls.spotlight_user = create_user(
+            username='resolver-spotlight',
+            user_permissions=('can_view_spotlight',),
+        )
+        cls.normal_user = create_user(username='resolver-normal')
+        cls.live_user = create_user(username='resolver-live')
+        cls.live_user.profile.username_display_override = '</script><script>alert(1)</script>'
+        cls.live_user.profile.save(update_fields=['username_display_override'])
+        cls.virtual_user = create_user(username='resolver-virtual')
+        cls.spectator = create_user(username='resolver-spectator')
+
+        cls.contest = Contest.objects.create(
+            key='resolver-payload',
+            name='Resolver </script> Contest',
+            description='',
+            summary='Resolver payload test contest.',
+            og_image='/resolver.png',
+            start_time=now - timezone.timedelta(days=2),
+            end_time=now - timezone.timedelta(days=1),
+            format_name='icpc',
+            format_config={'penalty': 17},
+            frozen_last_minutes=60,
+            is_visible=True,
+            allow_spotlight=True,
+        )
+        cls.contest.authors.add(cls.editor.profile)
+        first_problem = create_problem(code='resolver_first', name='Resolver First')
+        second_problem = create_problem(code='resolver_second', name='Resolver Second')
+        cls.later_problem = create_contest_problem(
+            contest=cls.contest,
+            problem=first_problem,
+            points=1,
+            order=20,
+        )
+        cls.earlier_problem = create_contest_problem(
+            contest=cls.contest,
+            problem=second_problem,
+            points=1,
+            order=7,
+        )
+
+        cls.live = create_contest_participation(
+            contest=cls.contest,
+            user=cls.live_user.profile,
+            virtual=ContestParticipation.LIVE,
+            score=1,
+            cumtime=42,
+            tiebreaker=30,
+            frozen_score=0,
+            frozen_cumtime=0,
+            frozen_tiebreaker=0,
+            format_data={
+                str(cls.earlier_problem.id): {
+                    'points': 1,
+                    'time': 1800,
+                    'tries': 2,
+                    'frozen_points': 0,
+                    'frozen_tries': 2,
+                    'is_frozen': True,
+                },
+            },
+        )
+        create_contest_participation(
+            contest=cls.contest,
+            user=cls.virtual_user.profile,
+            virtual=1,
+            score=1,
+        )
+        create_contest_participation(
+            contest=cls.contest,
+            user=cls.spectator.profile,
+            virtual=ContestParticipation.SPECTATE,
+            score=1,
+        )
+
+    def fresh_contest(self, **updates):
+        if updates:
+            Contest.objects.filter(pk=self.contest.pk).update(**updates)
+        return Contest.objects.get(pk=self.contest.pk)
+
+    def resolver_view(self, user, contest=None):
+        request = RequestFactory().get(reverse('spotlight_ranking', args=[self.contest.key]))
+        request.user = user
+        request.profile = user.profile
+        request.LANGUAGE_CODE = 'vi'
+        view = SpotlightContestRanking()
+        view.setup(request, contest=self.contest.key)
+        view.object = contest or self.fresh_contest()
+        return view
+
+    def test_payload_preserves_problem_order_labels_live_scope_and_icpc_fields(self):
+        payload = build_resolver_payload(self.fresh_contest())
+
+        self.assertEqual(payload['schema_version'], 1)
+        self.assertEqual(payload['contest']['format'], 'icpc')
+        self.assertEqual(payload['contest']['format_config'], {'penalty': 17})
+        self.assertEqual(payload['contest']['rank_display_options'], self.contest.rank_display_options)
+        self.assertTrue(payload['contest']['official_freeze_available'])
+        self.assertEqual(
+            [(problem['id'], problem['label'], problem['order']) for problem in payload['problems']],
+            [
+                (self.earlier_problem.id, 'A', 7),
+                (self.later_problem.id, 'B', 20),
+            ],
+        )
+        self.assertEqual([contestant['username'] for contestant in payload['contestants']], ['resolver-live'])
+
+        contestant = payload['contestants'][0]
+        self.assertTrue(contestant['profile_url'].endswith('/user/resolver-live'))
+        self.assertEqual(contestant['user_css_class'], self.live_user.profile.css_class)
+        self.assertIn('avatar_url', contestant)
+        self.assertIn('rank_logo_url', contestant)
+        cell = contestant['problems'][str(self.earlier_problem.id)]
+        self.assertEqual(cell['final'], {'points': 1, 'time': 1800, 'tries': 2})
+        self.assertEqual(cell['frozen'], {
+            'points': 0,
+            'time': 1800,
+            'tries': 2,
+            'pending': True,
+        })
+        self.assertEqual(contestant['final'], {'score': 1, 'cumtime': 42, 'tiebreaker': 30})
+        self.assertEqual(contestant['frozen'], {'score': 0, 'cumtime': 0, 'tiebreaker': 0})
+
+    def test_default_payload_has_no_official_freeze(self):
+        self.live.score = 0.5
+        self.live.cumtime = 125
+        self.live.tiebreaker = 0
+        self.live.format_data = {
+            str(self.earlier_problem.id): {'points': 0.5, 'time': 125},
+        }
+        self.live.save(update_fields=['score', 'cumtime', 'tiebreaker', 'format_data'])
+
+        payload = build_resolver_payload(self.fresh_contest(
+            format_name='default',
+            format_config=None,
+            frozen_last_minutes=0,
+        ))
+        self.assertEqual(payload['contest']['format_config'], {})
+        self.assertFalse(payload['contest']['official_freeze_available'])
+        contestant = payload['contestants'][0]
+        self.assertIsNone(contestant['frozen'])
+        self.assertEqual(contestant['problems'][str(self.earlier_problem.id)], {
+            'problem_id': self.earlier_problem.id,
+            'attempted': True,
+            'final': {'points': 0.5, 'time': 125},
+            'frozen': None,
+        })
+
+    def test_vnoj_payload_normalizes_config_and_preserves_pending_frozen_fields(self):
+        self.live.score = 75
+        self.live.cumtime = 900
+        self.live.tiebreaker = 600
+        self.live.frozen_score = 50
+        self.live.frozen_cumtime = 500
+        self.live.frozen_tiebreaker = 300
+        self.live.format_data = {
+            str(self.earlier_problem.id): {
+                'points': 75,
+                'time': 600,
+                'penalty': 1,
+                'pending': 2,
+                'frozen_points': 50,
+                'frozen_time': 300,
+                'frozen_penalty': 0,
+            },
+        }
+        self.live.save()
+
+        payload = build_resolver_payload(self.fresh_contest(
+            format_name='vnoj',
+            format_config={'LSO': True},
+            frozen_last_minutes=45,
+        ))
+        self.assertEqual(payload['contest']['format_config'], {'penalty': 5, 'LSO': True})
+        cell = payload['contestants'][0]['problems'][str(self.earlier_problem.id)]
+        self.assertEqual(cell['final'], {'points': 75, 'time': 600, 'penalty': 1, 'pending': 2})
+        self.assertEqual(cell['frozen'], {'points': 50, 'time': 300, 'penalty': 0, 'pending': 2})
+
+    def test_unsupported_format_rejects_without_fallback(self):
+        contest = self.fresh_contest(format_name='atcoder', format_config=None)
+        with self.assertRaisesRegex(ResolverUnsupportedFormat, 'atcoder'):
+            build_resolver_payload(contest)
+
+    def test_spotlight_view_enforces_operator_authorization_and_escapes_payload(self):
+        url = reverse('spotlight_ranking', args=[self.contest.key])
+        self.assertIs(resolve(url).func.view_class, SpotlightContestRanking)
+
+        with self.assertRaises(PermissionDenied):
+            self.resolver_view(self.normal_user).get_context_data(object=self.contest)
+
+        for user in (self.editor, self.spotlight_user):
+            context = self.resolver_view(user).get_context_data(object=self.contest)
+            script = str(context['resolver_data_script'])
+            self.assertIn('id="resolver-data"', script)
+            self.assertNotIn('</script><script>alert(1)</script>', script)
+            self.assertIn(r'\u003C/script\u003E', script)
+
+    def test_unsupported_view_renders_clear_error(self):
+        contest = self.fresh_contest(format_name='atcoder', format_config=None)
+        context = self.resolver_view(self.editor, contest).get_context_data(object=contest)
+        self.assertIn('not supported by Resolver', context['resolver_error'])
+        self.assertIsNone(context['resolver_data_script'])
+
+    def test_spotlight_template_has_phase_three_ceremony_shell(self):
+        source = (Path(settings.BASE_DIR) / 'templates/contest/spotlight-ranking.html').read_text(
+            encoding='utf-8',
+        )
+
+        self.assertIn('id="resolver-setup"', source)
+        self.assertIn('id="ranking-table"', source)
+        self.assertIn('id="resolver-play"', source)
+        self.assertIn('id="resolver-hud"', source)
+        self.assertIn('id="resolver-shortcuts"', source)
+        self.assertIn('id="resolver-fullscreen"', source)
+        self.assertIn('data-resolver-preset="icpc"', source)
+        self.assertIn('resolver/resolver.css', source)
+        self.assertIn('resolver/bootstrap.js', source)
+        self.assertNotIn('resolver-debug-output', source)
+        self.assertNotIn('Resolver Phase 1 semantic core loaded.', source)

--- a/judge/models/tests/test_resolver.py
+++ b/judge/models/tests/test_resolver.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 
 from django.conf import settings
+from django.contrib.auth.context_processors import PermWrapper
 from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory, TestCase, override_settings
+from django.template.loader import get_template
 from django.urls import resolve, reverse
 from django.utils import timezone
 
 from judge.models import Contest, ContestParticipation
-from judge.models.tests.util import create_contest_participation, create_contest_problem, create_problem, create_user
+from judge.models.contest import RankDisplayOptions
+from judge.models.tests.util import create_contest_participation, create_contest_problem, create_organization, \
+    create_problem, create_user
 from judge.resolver import ResolverUnsupportedFormat, build_resolver_payload
 from judge.views.contests import SpotlightContestRanking
 
@@ -28,8 +32,24 @@ class ResolverPayloadTestCase(TestCase):
         )
         cls.normal_user = create_user(username='resolver-normal')
         cls.live_user = create_user(username='resolver-live')
+        cls.live_user.first_name = 'Resolver Live Name'
+        cls.live_user.save(update_fields=['first_name'])
         cls.live_user.profile.username_display_override = '</script><script>alert(1)</script>'
         cls.live_user.profile.save(update_fields=['username_display_override'])
+        cls.visible_organizations = [
+            create_organization(name='Resolver Alpha Org', slug='resolver-alpha', short_name='RA', is_unlisted=False),
+            create_organization(name='Resolver Beta Org', slug='resolver-beta', short_name='RB', is_unlisted=False),
+        ]
+        cls.unlisted_organization = create_organization(
+            name='Resolver Hidden Org',
+            slug='resolver-hidden',
+            short_name='RH',
+            is_unlisted=True,
+        )
+        cls.live_user.profile.organizations.add(
+            *cls.visible_organizations,
+            cls.unlisted_organization,
+        )
         cls.virtual_user = create_user(username='resolver-virtual')
         cls.spectator = create_user(username='resolver-spectator')
 
@@ -132,8 +152,19 @@ class ResolverPayloadTestCase(TestCase):
         contestant = payload['contestants'][0]
         self.assertTrue(contestant['profile_url'].endswith('/user/resolver-live'))
         self.assertEqual(contestant['user_css_class'], self.live_user.profile.css_class)
+        self.assertEqual(contestant['full_name'], 'Resolver Live Name')
         self.assertIn('avatar_url', contestant)
         self.assertIn('rank_logo_url', contestant)
+        self.assertEqual(contestant['final_order'], 0)
+        self.assertEqual(contestant['frozen_order'], 0)
+        self.assertEqual(
+            [(organization['short_name'], organization['url']) for organization in contestant['organizations']],
+            [('RA', '/organization/resolver-alpha'), ('RB', '/organization/resolver-beta')],
+        )
+        self.assertNotIn('RH', [organization['short_name'] for organization in contestant['organizations']])
+        problem = payload['problems'][0]
+        self.assertEqual(problem['first_solve_participation_id'], self.live.id)
+        self.assertEqual(problem['final_total_ac'], 1)
         cell = contestant['problems'][str(self.earlier_problem.id)]
         self.assertEqual(cell['final'], {'points': 1, 'time': 1800, 'tries': 2})
         self.assertEqual(cell['frozen'], {
@@ -169,6 +200,36 @@ class ResolverPayloadTestCase(TestCase):
             'final': {'points': 0.5, 'time': 125},
             'frozen': None,
         })
+
+    def test_rank_display_options_are_serialized_without_an_independent_resolver_default(self):
+        for option in (
+                RankDisplayOptions.AVATAR,
+                RankDisplayOptions.LOGO,
+                RankDisplayOptions.HIDDEN,
+        ):
+            with self.subTest(option=option):
+                payload = build_resolver_payload(self.fresh_contest(rank_display_options=option))
+                self.assertEqual(payload['contest']['rank_display_options'], option)
+                self.assertIn('avatar_url', payload['contestants'][0])
+                self.assertIn('rank_logo_url', payload['contestants'][0])
+
+    def test_identity_payload_prefetches_multiple_organizations_without_n_plus_one_queries(self):
+        second_user = create_user(username='resolver-second-live')
+        second_user.profile.organizations.add(*self.visible_organizations)
+        create_contest_participation(
+            contest=self.contest,
+            user=second_user.profile,
+            virtual=ContestParticipation.LIVE,
+            format_data={},
+        )
+
+        contest = self.fresh_contest()
+        # Problems, final order, frozen order, rich participations, and one
+        # organization prefetch: this count must stay constant as users grow.
+        with self.assertNumQueries(5):
+            payload = build_resolver_payload(contest)
+        self.assertEqual(len(payload['contestants']), 2)
+        self.assertTrue(all(len(contestant['organizations']) == 2 for contestant in payload['contestants']))
 
     def test_vnoj_payload_normalizes_config_and_preserves_pending_frozen_fields(self):
         self.live.score = 75
@@ -218,6 +279,30 @@ class ResolverPayloadTestCase(TestCase):
             self.assertIn('id="resolver-data"', script)
             self.assertNotIn('</script><script>alert(1)</script>', script)
             self.assertIn(r'\u003C/script\u003E', script)
+
+    def test_spotlight_tab_visibility_matches_resolver_authorization(self):
+        resolver_url = reverse('spotlight_ranking', args=[self.contest.key])
+        template = get_template('contest/contest-tabs.html')
+
+        def render_tabs(user, can_edit):
+            request = RequestFactory().get(reverse('contest_view', args=[self.contest.key]))
+            request.user = user
+            request.profile = user.profile
+            return template.template.render({
+                'contest': self.fresh_contest(),
+                'request': request,
+                'now': timezone.now(),
+                'can_edit': can_edit,
+                'is_editor': can_edit,
+                'is_tester': False,
+                'is_in_contest': False,
+                'has_joined': False,
+                'has_moss_api_key': False,
+                'perms': PermWrapper(user),
+            })
+
+        self.assertNotIn(resolver_url, render_tabs(self.normal_user, False))
+        self.assertIn(resolver_url, render_tabs(self.editor, True))
 
     def test_unsupported_view_renders_clear_error(self):
         contest = self.fresh_contest(format_name='atcoder', format_config=None)

--- a/judge/models/tests/test_resolver_demo.py
+++ b/judge/models/tests/test_resolver_demo.py
@@ -1,0 +1,103 @@
+from io import StringIO
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from judge.management.commands.seed_resolver_demo import CONTEST_BLUEPRINTS, DEMO_MARKER, DEMO_USERS
+from judge.models import Contest, ContestParticipation, ContestSubmission
+from judge.resolver import build_resolver_payload
+
+
+@override_settings(DEBUG=True, MOSS_API_KEY=None)
+class ResolverDemoCommandTestCase(TestCase):
+    fixtures = ['language_all.json']
+
+    def test_seeds_real_submissions_freeze_cases_tie_and_disqualification(self):
+        stdout = StringIO()
+        call_command('seed_resolver_demo', stdout=stdout)
+
+        self.assertIn('Resolver demo data is ready.', stdout.getvalue())
+        self.assertEqual(
+            set(Contest.objects.filter(summary__contains=DEMO_MARKER).values_list('key', flat=True)),
+            {blueprint['key'] for blueprint in CONTEST_BLUEPRINTS.values()},
+        )
+
+        for format_name, blueprint in CONTEST_BLUEPRINTS.items():
+            contest = Contest.objects.get(key=blueprint['key'])
+            payload = build_resolver_payload(contest)
+
+            self.assertTrue(contest.ended)
+            self.assertEqual(contest.format_name, format_name)
+            self.assertEqual(contest.user_count, len(DEMO_USERS))
+            self.assertEqual(len(payload['contestants']), len(DEMO_USERS))
+            self.assertEqual(
+                ContestSubmission.objects.filter(participation__contest=contest).count(),
+                len(blueprint['submissions']),
+            )
+            self.assertFalse(contest.users.filter(format_data__isnull=True).exists())
+
+            hugo = contest.users.get(user__user__username='resolver_hugo')
+            self.assertTrue(hugo.is_disqualified)
+            self.assertEqual((hugo.score, hugo.cumtime, hugo.tiebreaker), (-9999, 0, 0))
+
+            if blueprint['frozen_last_minutes']:
+                self.assertTrue(payload['contest']['official_freeze_available'])
+                self.assertTrue(any(
+                    cell['frozen'] and cell['frozen'].get('pending')
+                    for contestant in payload['contestants']
+                    for cell in contestant['problems'].values()
+                ))
+            else:
+                self.assertFalse(payload['contest']['official_freeze_available'])
+
+        icpc = Contest.objects.get(key=CONTEST_BLUEPRINTS['icpc']['key'])
+        chen = icpc.users.get(user__user__username='resolver_chen')
+        elena = icpc.users.get(user__user__username='resolver_elena')
+        self.assertEqual(
+            (chen.score, chen.cumtime, chen.tiebreaker),
+            (elena.score, elena.cumtime, elena.tiebreaker),
+        )
+        self.assertNotEqual(chen.submissions.count(), elena.submissions.count())
+
+        vnoj = Contest.objects.get(key=CONTEST_BLUEPRINTS['vnoj']['key'])
+        gia = vnoj.users.get(user__user__username='resolver_gia')
+        self.assertEqual((gia.score, gia.cumtime, gia.tiebreaker), (0, 0, 0))
+        self.assertGreater(gia.submissions.count(), 0)
+
+    def test_existing_data_is_kept_and_owned_contest_can_be_replaced(self):
+        call_command('seed_resolver_demo', format='default', stdout=StringIO())
+        contest = Contest.objects.get(key=CONTEST_BLUEPRINTS['default']['key'])
+        original_id = contest.id
+        original_counts = (
+            Contest.objects.count(),
+            ContestParticipation.objects.count(),
+            ContestSubmission.objects.count(),
+            User.objects.count(),
+        )
+
+        stdout = StringIO()
+        call_command('seed_resolver_demo', format='default', stdout=stdout)
+        self.assertIn('Kept existing resolver_demo_default', stdout.getvalue())
+        self.assertEqual(original_counts, (
+            Contest.objects.count(),
+            ContestParticipation.objects.count(),
+            ContestSubmission.objects.count(),
+            User.objects.count(),
+        ))
+
+        call_command('seed_resolver_demo', format='default', replace=True, stdout=StringIO())
+        replacement = Contest.objects.get(key=CONTEST_BLUEPRINTS['default']['key'])
+        self.assertNotEqual(replacement.id, original_id)
+        self.assertEqual(original_counts, (
+            Contest.objects.count(),
+            ContestParticipation.objects.count(),
+            ContestSubmission.objects.count(),
+            User.objects.count(),
+        ))
+
+    @override_settings(DEBUG=False)
+    def test_rejects_non_debug_database(self):
+        with self.assertRaisesRegex(CommandError, 'requires DEBUG=True'):
+            call_command('seed_resolver_demo', stdout=StringIO())

--- a/judge/models/tests/test_resolver_demo.py
+++ b/judge/models/tests/test_resolver_demo.py
@@ -3,6 +3,7 @@ from io import StringIO
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db.models import Count
 from django.test import TestCase, override_settings
 
 from judge.management.commands.seed_resolver_demo import CONTEST_BLUEPRINTS, DEMO_MARKER, DEMO_USERS
@@ -32,6 +33,26 @@ class ResolverDemoCommandTestCase(TestCase):
             self.assertEqual(contest.format_name, format_name)
             self.assertEqual(contest.user_count, len(DEMO_USERS))
             self.assertEqual(len(payload['contestants']), len(DEMO_USERS))
+            expected_order = list(
+                contest.users.filter(virtual=ContestParticipation.LIVE)
+                .annotate(submission_count=Count('submission'))
+                .order_by(
+                    'is_disqualified',
+                    '-score',
+                    'cumtime',
+                    'tiebreaker',
+                    '-submission_count',
+                )
+                .values_list('id', flat=True)
+            )
+            self.assertEqual(
+                [contestant['participation_id'] for contestant in payload['contestants']],
+                expected_order,
+            )
+            self.assertEqual(
+                [contestant['final_order'] for contestant in payload['contestants']],
+                list(range(len(DEMO_USERS))),
+            )
             self.assertEqual(
                 ContestSubmission.objects.filter(participation__contest=contest).count(),
                 len(blueprint['submissions']),

--- a/judge/resolver.py
+++ b/judge/resolver.py
@@ -1,6 +1,7 @@
+from django.conf import settings
 from django.db.models import Count, Prefetch
 
-from judge.jinja2.gravatar import gravatar
+from judge.jinja2.gravatar import fallback as gravatar_fallback, gravatar
 from judge.models import ContestParticipation, Organization
 
 
@@ -95,7 +96,9 @@ def _serialize_avatar(profile):
             return profile.avt_url.url
         except ValueError:
             pass
-    return gravatar(profile.user, 64)
+    if settings.DEBUG:
+        return gravatar(profile.user, 64)
+    return gravatar_fallback(profile.user.email, 64, None)
 
 
 def _serialize_rank_logo(profile):
@@ -107,9 +110,20 @@ def _serialize_rank_logo(profile):
         return None
 
 
-def _serialize_participation(participation, problems, format_name, official_freeze_available):
+def _serialize_organizations(profile):
+    return [
+        {
+            'name': organization.name,
+            'short_name': organization.short_name,
+            'url': organization.get_absolute_url(),
+        }
+        for organization in profile.organizations.all()
+    ]
+
+
+def _serialize_participation(participation, problems, format_name, official_freeze_available,
+                             final_order, frozen_order):
     profile = participation.user
-    organization = profile.organization
     format_data = participation.format_data or {}
     if not isinstance(format_data, dict):
         raise ResolverPayloadError(
@@ -143,16 +157,16 @@ def _serialize_participation(participation, problems, format_name, official_free
         'profile_id': profile.id,
         'username': profile.username,
         'display_name': profile.display_name,
+        'full_name': profile.user.first_name,
         'user_css_class': profile.css_class,
         'profile_url': profile.get_absolute_url(),
         'avatar_url': _serialize_avatar(profile),
         'rank_logo_url': _serialize_rank_logo(profile),
-        'organization': None if organization is None else {
-            'name': organization.name,
-            'short_name': organization.short_name,
-        },
+        'organizations': _serialize_organizations(profile),
         'is_disqualified': participation.is_disqualified,
         'submission_count': participation.submission_count,
+        'final_order': final_order,
+        'frozen_order': frozen_order,
         'final': {
             'score': participation.score,
             'cumtime': participation.cumtime,
@@ -171,19 +185,55 @@ def build_resolver_payload(contest):
     problems = list(
         contest.contest_problems.select_related('problem').defer('problem__description').order_by('order'),
     )
-    participations = contest.users.filter(virtual=ContestParticipation.LIVE) \
-        .select_related('user__user', 'user__user_rank_logo') \
-        .prefetch_related(Prefetch(
-            'user__organizations',
-            queryset=Organization.objects.filter(is_unlisted=False),
-        )) \
-        .annotate(submission_count=Count('submission')) \
-        .order_by('id')
+    ranking_queryset = contest.users.filter(virtual=ContestParticipation.LIVE).annotate(
+        submission_count=Count('submission'),
+    )
+    final_participation_ids = list(
+        ranking_queryset
+        .order_by('is_disqualified', '-score', 'cumtime', 'tiebreaker', '-submission_count')
+        .values_list('id', flat=True),
+    )
+    frozen_participation_ids = list(
+        ranking_queryset
+        .order_by(
+            'is_disqualified', '-frozen_score', 'frozen_cumtime', 'frozen_tiebreaker', '-submission_count',
+        )
+        .values_list('id', flat=True),
+    )
+
+    participation_by_id = {
+        participation.id: participation
+        for participation in (
+            contest.users.filter(id__in=final_participation_ids)
+            .select_related('user__user', 'user__user_rank_logo', 'rating')
+            .defer('user__about', 'user__organizations__about')
+            .prefetch_related(Prefetch(
+                'user__organizations',
+                queryset=Organization.objects.filter(is_unlisted=False),
+            ))
+            .annotate(submission_count=Count('submission'))
+        )
+    }
+    participations = [participation_by_id[participation_id] for participation_id in final_participation_ids]
+
+    final_order = {
+        participation.id: index
+        for index, participation in enumerate(participations)
+    }
+    frozen_order = {
+        participation_id: index
+        for index, participation_id in enumerate(frozen_participation_ids)
+    }
 
     official_freeze_available = (
         format_name in FROZEN_RESOLVER_FORMATS and contest.frozen_last_minutes > 0
     )
     format_config = contest.format.config or {}
+    first_solves, total_ac = contest.format.get_first_solves_and_total_ac(
+        problems,
+        participations,
+        frozen=False,
+    )
 
     return {
         'schema_version': 1,
@@ -206,6 +256,8 @@ def build_resolver_payload(contest):
                 'name': problem.problem.name,
                 'order': problem.order,
                 'max_score': problem.points,
+                'first_solve_participation_id': first_solves.get(str(problem.id)),
+                'final_total_ac': total_ac.get(str(problem.id), 0),
             }
             for index, problem in enumerate(problems)
         ],
@@ -215,6 +267,8 @@ def build_resolver_payload(contest):
                 problems,
                 format_name,
                 official_freeze_available,
+                final_order[participation.id],
+                frozen_order[participation.id],
             )
             for participation in participations
         ],

--- a/judge/resolver.py
+++ b/judge/resolver.py
@@ -1,0 +1,221 @@
+from django.db.models import Count, Prefetch
+
+from judge.jinja2.gravatar import gravatar
+from judge.models import ContestParticipation, Organization
+
+
+SUPPORTED_RESOLVER_FORMATS = frozenset(('default', 'icpc', 'vnoj'))
+FROZEN_RESOLVER_FORMATS = frozenset(('icpc', 'vnoj'))
+
+
+class ResolverPayloadError(ValueError):
+    pass
+
+
+class ResolverUnsupportedFormat(ResolverPayloadError):
+    def __init__(self, format_name):
+        super().__init__('Contest format "%s" is not supported by Resolver.' % format_name)
+        self.format_name = format_name
+
+
+def _number(data, key, default=0):
+    value = data.get(key, default)
+    return default if value is None else value
+
+
+def _serialize_default_cell(problem_id, data, official_freeze_available):
+    return {
+        'problem_id': problem_id,
+        'attempted': True,
+        'final': {
+            'points': _number(data, 'points'),
+            'time': _number(data, 'time'),
+        },
+        'frozen': None,
+    }
+
+
+def _serialize_icpc_cell(problem_id, data, official_freeze_available):
+    frozen = None
+    if official_freeze_available:
+        frozen = {
+            'points': _number(data, 'frozen_points'),
+            # The Python format stores one solve time and uses it for both final and frozen displays.
+            'time': _number(data, 'time'),
+            'tries': _number(data, 'frozen_tries'),
+            'pending': bool(data.get('is_frozen', False)),
+        }
+
+    return {
+        'problem_id': problem_id,
+        'attempted': True,
+        'final': {
+            'points': _number(data, 'points'),
+            'time': _number(data, 'time'),
+            'tries': _number(data, 'tries'),
+        },
+        'frozen': frozen,
+    }
+
+
+def _serialize_vnoj_cell(problem_id, data, official_freeze_available):
+    pending = _number(data, 'pending')
+    frozen = None
+    if official_freeze_available:
+        frozen = {
+            'points': _number(data, 'frozen_points'),
+            'time': _number(data, 'frozen_time'),
+            'penalty': _number(data, 'frozen_penalty'),
+            'pending': pending,
+        }
+
+    return {
+        'problem_id': problem_id,
+        'attempted': True,
+        'final': {
+            'points': _number(data, 'points'),
+            'time': _number(data, 'time'),
+            'penalty': _number(data, 'penalty'),
+            'pending': pending,
+        },
+        'frozen': frozen,
+    }
+
+
+CELL_SERIALIZERS = {
+    'default': _serialize_default_cell,
+    'icpc': _serialize_icpc_cell,
+    'vnoj': _serialize_vnoj_cell,
+}
+
+
+def _serialize_avatar(profile):
+    if profile.avt_url:
+        try:
+            return profile.avt_url.url
+        except ValueError:
+            pass
+    return gravatar(profile.user, 64)
+
+
+def _serialize_rank_logo(profile):
+    if not profile.user_rank_logo:
+        return None
+    try:
+        return profile.user_rank_logo.image.url
+    except ValueError:
+        return None
+
+
+def _serialize_participation(participation, problems, format_name, official_freeze_available):
+    profile = participation.user
+    organization = profile.organization
+    format_data = participation.format_data or {}
+    if not isinstance(format_data, dict):
+        raise ResolverPayloadError(
+            'Participation %s has invalid resolver format data.' % participation.id,
+        )
+
+    cells = {}
+    serializer = CELL_SERIALIZERS[format_name]
+    for problem in problems:
+        problem_id = str(problem.id)
+        data = format_data.get(problem_id)
+        if data is None:
+            continue
+        if not isinstance(data, dict):
+            raise ResolverPayloadError(
+                'Participation %s has invalid resolver data for problem %s.' %
+                (participation.id, problem.id),
+            )
+        cells[problem_id] = serializer(problem.id, data, official_freeze_available)
+
+    frozen = None
+    if official_freeze_available:
+        frozen = {
+            'score': participation.frozen_score,
+            'cumtime': participation.frozen_cumtime,
+            'tiebreaker': participation.frozen_tiebreaker,
+        }
+
+    return {
+        'participation_id': participation.id,
+        'profile_id': profile.id,
+        'username': profile.username,
+        'display_name': profile.display_name,
+        'user_css_class': profile.css_class,
+        'profile_url': profile.get_absolute_url(),
+        'avatar_url': _serialize_avatar(profile),
+        'rank_logo_url': _serialize_rank_logo(profile),
+        'organization': None if organization is None else {
+            'name': organization.name,
+            'short_name': organization.short_name,
+        },
+        'is_disqualified': participation.is_disqualified,
+        'submission_count': participation.submission_count,
+        'final': {
+            'score': participation.score,
+            'cumtime': participation.cumtime,
+            'tiebreaker': participation.tiebreaker,
+        },
+        'frozen': frozen,
+        'problems': cells,
+    }
+
+
+def build_resolver_payload(contest):
+    format_name = contest.format_name
+    if format_name not in SUPPORTED_RESOLVER_FORMATS:
+        raise ResolverUnsupportedFormat(format_name)
+
+    problems = list(
+        contest.contest_problems.select_related('problem').defer('problem__description').order_by('order'),
+    )
+    participations = contest.users.filter(virtual=ContestParticipation.LIVE) \
+        .select_related('user__user', 'user__user_rank_logo') \
+        .prefetch_related(Prefetch(
+            'user__organizations',
+            queryset=Organization.objects.filter(is_unlisted=False),
+        )) \
+        .annotate(submission_count=Count('submission')) \
+        .order_by('id')
+
+    official_freeze_available = (
+        format_name in FROZEN_RESOLVER_FORMATS and contest.frozen_last_minutes > 0
+    )
+    format_config = contest.format.config or {}
+
+    return {
+        'schema_version': 1,
+        'contest': {
+            'id': contest.id,
+            'key': contest.key,
+            'name': contest.name,
+            'format': format_name,
+            'format_config': format_config,
+            'rank_display_options': contest.rank_display_options,
+            'points_precision': contest.points_precision,
+            'frozen_last_minutes': contest.frozen_last_minutes,
+            'official_freeze_available': official_freeze_available,
+        },
+        'problems': [
+            {
+                'id': problem.id,
+                'code': problem.problem.code,
+                'label': contest.get_label_for_problem(index),
+                'name': problem.problem.name,
+                'order': problem.order,
+                'max_score': problem.points,
+            }
+            for index, problem in enumerate(problems)
+        ],
+        'contestants': [
+            _serialize_participation(
+                participation,
+                problems,
+                format_name,
+                official_freeze_available,
+            )
+            for participation in participations
+        ],
+    }

--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -27,7 +27,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.html import escape, format_html
+from django.utils.html import escape, format_html, json_script
 from django.utils.safestring import mark_safe
 from django.utils.timezone import make_aware
 from django.utils.translation import gettext as _, gettext_lazy
@@ -47,6 +47,7 @@ from judge.forms import ContestAnnouncementForm, ContestCloneForm, ContestDownlo
     ProposeContestProblemFormSet
 from judge.models import Contest, ContestAnnouncement, ContestMoss, ContestParticipation, ContestProblem, ContestTag, \
     Organization, Problem, ProblemClarification, Profile, Submission, WarningLog
+from judge.resolver import ResolverPayloadError, build_resolver_payload
 from judge.tasks import on_new_contest, prepare_contest_data, run_moss
 from judge.utils.celery import redirect_to_task_status, task_status_by_id, task_status_url_by_id
 from judge.utils.cms import parse_csv_ranking
@@ -1131,134 +1132,27 @@ class ContestRanking(ContestRankingBase):
         return context
 
 
-class SpotlightContestRankingBase(ContestMixin, TitleMixin, DetailView):
+class SpotlightContestRanking(ContestMixin, TitleMixin, DetailView):
     template_name = 'contest/spotlight-ranking.html'
-    ranking_table_template = get_template('contest/spotlight-ranking-table.html')
-    tab = None
-
-    def get_title(self):
-        raise NotImplementedError()
-
-    def get_content_title(self):
-        return self.object.name
-
-    def get_ranking_list(self):
-        raise NotImplementedError()
-
-    @property
-    def is_frozen(self):
-        return False
-
-    def check_can_see_own_scoreboard(self):
-        if not self.object.can_see_own_scoreboard(self.request.user):
-            raise Http404()
-
-    def get_rendered_ranking_table(self):
-        users, problems, total_ac = self.get_ranking_list()
-
-        return self.ranking_table_template.render(request=self.request, context={
-            'table_id': 'ranking-table',
-            'users': users,
-            'problems': problems,
-            'total_ac': total_ac,
-            'contest': self.object,
-            'has_rating': self.object.ratings.exists(),
-            'is_frozen': self.is_frozen,
-            'perms': PermWrapper(self.request.user),
-            'can_edit': self.can_edit,
-            'is_ICPC_format': (self.object.format.name == ICPCContestFormat.name),
-        })
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        self.check_can_see_own_scoreboard()
-
-        context['rendered_ranking_table'] = self.get_rendered_ranking_table()
-        context['tab'] = self.tab
-        return context
-
-    def get(self, request, *args, **kwargs):
-        if 'raw' in request.GET:
-            self.object = self.get_object()
-
-            self.check_can_see_own_scoreboard()
-
-            return HttpResponse(self.get_rendered_ranking_table(), content_type='text/plain')
-        return super().get(request, *args, **kwargs)
-
-
-class SpotlightContestRanking(SpotlightContestRankingBase):
     tab = 'spotlight_ranking'
-    show_virtual = False
 
     def get_title(self):
-        return _('%s Rescore Rankings') % self.object.name
-
-    @cached_property
-    def is_frozen(self):
-        return self.object.is_frozen and not self.can_edit
-
-    @property
-    def cache_key(self):
-        return f'contest_ranking_cache_{self.object.key}_{self.show_virtual}_{self.is_frozen}_' \
-               f'{self.request.LANGUAGE_CODE}'
-
-    @property
-    def bypass_cache_ranking(self):
-        return self.object.scoreboard_cache_timeout == 0 or self.can_edit or \
-            (self.request.user.is_authenticated and not self.object.can_see_full_scoreboard(self.request.user))
-
-    def get_ranking_queryset(self):
-        if self.is_frozen:
-            queryset = base_contest_frozen_ranking_queryset(self.object)
-        else:
-            queryset = base_contest_ranking_queryset(self.object)
-        if not self.show_virtual:
-            queryset = queryset.filter(virtual=ContestParticipation.LIVE)
-        return queryset
-
-    def get_full_ranking_list(self):
-        if 'show_virtual' in self.request.GET:
-            self.show_virtual = self.request.session['show_virtual'] \
-                              = self.request.GET.get('show_virtual').lower() == 'true'
-        else:
-            self.show_virtual = self.request.session.get('show_virtual', False)
-
-        queryset = self.get_ranking_queryset()
-        return get_contest_ranking_list(
-            self.request, self.object,
-            ranking_list=partial(base_contest_ranking_list, queryset=queryset, frozen=self.is_frozen),
-        )
-
-    def get_ranking_list(self):
-        if not self.object.can_see_full_scoreboard(self.request.user):
-            queryset = self.object.users.filter(user=self.request.profile, virtual=ContestParticipation.LIVE)
-            return get_contest_ranking_list(
-                self.request, self.object,
-                ranking_list=partial(base_contest_ranking_list, queryset=queryset),
-                ranker=lambda users, key: ((_('???'), user) for user in users),
-            )
-
-        return self.get_full_ranking_list()
-
-    def get_rendered_ranking_table(self):
-        if self.bypass_cache_ranking:
-            return super().get_rendered_ranking_table()
-
-        rendered_ranking_table = cache.get(self.cache_key, None)
-        if rendered_ranking_table is None:
-            rendered_ranking_table = super().get_rendered_ranking_table()
-            cache.set(self.cache_key, rendered_ranking_table, self.object.scoreboard_cache_timeout)
-
-        return rendered_ranking_table
+        return _('%s Resolver') % self.object.name
 
     def get_context_data(self, **kwargs):
+        if not (self.can_edit or self.request.user.has_perm('judge.can_view_spotlight')):
+            raise PermissionDenied
         context = super().get_context_data(**kwargs)
-        context['has_rating'] = self.object.ratings.exists()
-        context['show_virtual'] = self.show_virtual
-        context['is_frozen'] = self.is_frozen
-        context['cache_timeout'] = 0 if self.bypass_cache_ranking else self.object.scoreboard_cache_timeout
+
+        try:
+            payload = build_resolver_payload(self.object)
+        except ResolverPayloadError as error:
+            context['resolver_error'] = str(error)
+            context['resolver_data_script'] = None
+        else:
+            context['resolver_error'] = None
+            context['resolver_data_script'] = json_script(payload, 'resolver-data')
+        context['tab'] = self.tab
         return context
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "format": "prettier --write websocket",
-    "format:check": "prettier --check websocket"
+    "format:check": "prettier --check websocket",
+    "test:resolver": "node --test resources/resolver/tests/*.test.js"
   },
   "dependencies": {
     "@commander-js/extra-typings": "11.0.0",

--- a/resources/resolver/animation.js
+++ b/resources/resolver/animation.js
@@ -1,0 +1,87 @@
+function prefersReducedMotion() {
+  return window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function transitionPromise(element, duration, eventName) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      element.removeEventListener(eventName, finish);
+      resolve();
+    };
+    element.addEventListener(eventName, finish, { once: true });
+    window.setTimeout(finish, duration + 100);
+  });
+}
+
+export function captureRowPositions(tableBody) {
+  return new Map(
+    [...tableBody.querySelectorAll("tr[data-contestant-id]")].map((row) => [
+      row.dataset.contestantId,
+      row.getBoundingClientRect().top,
+    ]),
+  );
+}
+
+export async function animateRows(tableBody, previousPositions, duration = 700) {
+  if (!previousPositions.size || prefersReducedMotion()) {
+    return;
+  }
+
+  const movingRows = [...tableBody.querySelectorAll("tr[data-contestant-id]")]
+    .map((row) => {
+      const previousTop = previousPositions.get(row.dataset.contestantId);
+      if (previousTop === undefined) {
+        return null;
+      }
+      const delta = previousTop - row.getBoundingClientRect().top;
+      return Math.abs(delta) < 1 ? null : { row, delta };
+    })
+    .filter(Boolean);
+
+  movingRows.forEach(({ row, delta }) => {
+    row.style.transition = "none";
+    row.style.transform = `translateY(${delta}px)`;
+  });
+  if (!movingRows.length) {
+    return;
+  }
+
+  tableBody.getBoundingClientRect();
+  await new Promise((resolve) =>
+    window.requestAnimationFrame(() => window.requestAnimationFrame(resolve)),
+  );
+  const completions = movingRows.map(({ row }) => {
+    row.classList.add("resolver-row--moving");
+    row.style.transition = `transform ${duration}ms cubic-bezier(0.22, 1, 0.36, 1)`;
+    row.style.transform = "";
+    return transitionPromise(row, duration, "transitionend").then(() => {
+      row.classList.remove("resolver-row--moving");
+      row.style.removeProperty("transition");
+      row.style.removeProperty("transform");
+    });
+  });
+  await Promise.all(completions);
+}
+
+export async function animateChangedCells(tableBody, targets, duration = 560) {
+  if (!targets.length || prefersReducedMotion()) {
+    return;
+  }
+  const targetKeys = new Set(targets.map((target) => `${target.contestantId}:${target.problemId}`));
+  const cells = [...tableBody.querySelectorAll("td[data-problem-id]")].filter((cell) =>
+    targetKeys.has(`${cell.closest("tr").dataset.contestantId}:${cell.dataset.problemId}`),
+  );
+  await Promise.all(
+    cells.map((cell) => {
+      cell.classList.add("resolver-cell--changed");
+      return transitionPromise(cell, duration, "animationend").then(() =>
+        cell.classList.remove("resolver-cell--changed"),
+      );
+    }),
+  );
+}

--- a/resources/resolver/bootstrap.js
+++ b/resources/resolver/bootstrap.js
@@ -1,0 +1,19 @@
+import { ResolverPage } from "./page.js";
+
+const payloadElement = document.getElementById("resolver-data");
+const rootElement = document.getElementById("resolver-root");
+const errorElement = document.getElementById("resolver-client-error");
+
+if (payloadElement && rootElement) {
+  try {
+    const payload = JSON.parse(payloadElement.textContent);
+    const page = new ResolverPage(rootElement, payload);
+    page.mount();
+    window.CHTOJResolverPage = page;
+  } catch (error) {
+    if (errorElement) {
+      errorElement.hidden = false;
+      errorElement.textContent = `Resolver could not start: ${error.message}`;
+    }
+  }
+}

--- a/resources/resolver/controller.js
+++ b/resources/resolver/controller.js
@@ -1,34 +1,36 @@
 export const SPEED_PRESETS = Object.freeze([
-  Object.freeze({ label: "0.5×", delayMs: 2400 }),
-  Object.freeze({ label: "1×", delayMs: 1500 }),
-  Object.freeze({ label: "1.5×", delayMs: 850 }),
-  Object.freeze({ label: "2×", delayMs: 350 }),
+  Object.freeze({ label: "0.5×", speed: 0.5 }),
+  Object.freeze({ label: "1×", speed: 1 }),
+  Object.freeze({ label: "2×", speed: 2 }),
+  Object.freeze({ label: "4×", speed: 4 }),
 ]);
 
 export const CEREMONY_PRESETS = Object.freeze({
   icpc: Object.freeze({
     baseline: "auto",
-    policy: "bottom-up-sticky",
+    policy: "row-sweep",
     granularity: "cell",
     tieOrder: "seeded",
     speedIndex: 1,
-    pauseBeats: Object.freeze({
-      rankChange: true,
-      awardZone: true,
-      contestantFinished: true,
+    awardPlaces: 6,
+    singleStepStartRank: 6,
+    hardPauses: Object.freeze({
+      singleStep: true,
+      award: true,
       firstSolve: true,
     }),
   }),
   full: Object.freeze({
     baseline: "beginning",
-    policy: "bottom-up-sticky",
+    policy: "row-sweep",
     granularity: "cell",
     tieOrder: "seeded",
     speedIndex: 1,
-    pauseBeats: Object.freeze({
-      rankChange: true,
-      awardZone: true,
-      contestantFinished: true,
+    awardPlaces: 0,
+    singleStepStartRank: 0,
+    hardPauses: Object.freeze({
+      singleStep: false,
+      award: false,
       firstSolve: true,
     }),
   }),
@@ -38,10 +40,11 @@ export const CEREMONY_PRESETS = Object.freeze({
     granularity: "cell",
     tieOrder: "seeded",
     speedIndex: 1,
-    pauseBeats: Object.freeze({
-      rankChange: false,
-      awardZone: false,
-      contestantFinished: false,
+    awardPlaces: 0,
+    singleStepStartRank: 0,
+    hardPauses: Object.freeze({
+      singleStep: false,
+      award: false,
       firstSolve: false,
     }),
   }),
@@ -59,133 +62,6 @@ export function normalizeAwardPlaces(value, contestantCount) {
   return Math.min(parsed, Math.max(0, contestantCount));
 }
 
-export function getPauseReason(transitions, pauseBeats, awardPlaces) {
-  for (const transition of transitions) {
-    const effects = transition.effects;
-    if (
-      pauseBeats.awardZone &&
-      awardPlaces > 0 &&
-      effects.rankBefore > awardPlaces &&
-      effects.rankAfter <= awardPlaces
-    ) {
-      return `Entered the top ${awardPlaces} award zone.`;
-    }
-    if (pauseBeats.rankChange && effects.rankBefore !== effects.rankAfter) {
-      return `Rank changed from ${effects.rankBefore} to ${effects.rankAfter}.`;
-    }
-    if (pauseBeats.firstSolve && effects.firstSolveAppeared) {
-      return "A first solve appeared.";
-    }
-    if (pauseBeats.contestantFinished && effects.contestantFinished) {
-      return "Contestant fully resolved.";
-    }
-  }
-  return null;
-}
-
-function createDelay(duration) {
-  let timer = null;
-  let resolveDelay = null;
-  return {
-    promise: new Promise((resolve) => {
-      resolveDelay = resolve;
-      timer = globalThis.setTimeout(resolve, duration);
-    }),
-    cancel() {
-      if (timer !== null) {
-        globalThis.clearTimeout(timer);
-        timer = null;
-        resolveDelay();
-      }
-    },
-  };
-}
-
-export class AutoplayController {
-  constructor({ step, onChange = () => {}, speedIndex = 1 }) {
-    this.step = step;
-    this.onChange = onChange;
-    this.speedIndex = clampSpeedIndex(speedIndex);
-    this.playing = false;
-    this.pauseKind = "idle";
-    this.pauseReason = null;
-    this._runSerial = 0;
-    this._delay = null;
-  }
-
-  getState() {
-    return {
-      playing: this.playing,
-      pauseKind: this.pauseKind,
-      pauseReason: this.pauseReason,
-      speedIndex: this.speedIndex,
-      speed: SPEED_PRESETS[this.speedIndex],
-    };
-  }
-
-  setSpeed(index) {
-    this.speedIndex = clampSpeedIndex(index);
-    this.onChange(this.getState());
-    return this.getState();
-  }
-
-  slower() {
-    return this.setSpeed(this.speedIndex - 1);
-  }
-
-  faster() {
-    return this.setSpeed(this.speedIndex + 1);
-  }
-
-  play() {
-    if (this.playing) {
-      return;
-    }
-    this.playing = true;
-    this.pauseKind = null;
-    this.pauseReason = null;
-    const serial = ++this._runSerial;
-    this.onChange(this.getState());
-    void this._run(serial);
-  }
-
-  pause(reason = "Autoplay paused.", kind = "operator") {
-    this.playing = false;
-    this.pauseKind = kind;
-    this.pauseReason = reason;
-    this._runSerial += 1;
-    if (this._delay) {
-      this._delay.cancel();
-      this._delay = null;
-    }
-    this.onChange(this.getState());
-  }
-
-  toggle() {
-    if (this.playing) {
-      this.pause();
-    } else {
-      this.play();
-    }
-  }
-
-  async _run(serial) {
-    while (this.playing && serial === this._runSerial) {
-      const result = await this.step();
-      if (!this.playing || serial !== this._runSerial) {
-        return;
-      }
-      if (!result || result.complete) {
-        this.pause("Resolver complete — final standings reached.", "complete");
-        return;
-      }
-      if (result.pauseReason) {
-        this.pause(result.pauseReason, "beat");
-        return;
-      }
-      this._delay = createDelay(SPEED_PRESETS[this.speedIndex].delayMs);
-      await this._delay.promise;
-      this._delay = null;
-    }
-  }
+export function normalizeSingleStepStartRank(value, contestantCount) {
+  return normalizeAwardPlaces(value, contestantCount);
 }

--- a/resources/resolver/controller.js
+++ b/resources/resolver/controller.js
@@ -1,0 +1,191 @@
+export const SPEED_PRESETS = Object.freeze([
+  Object.freeze({ label: "0.5×", delayMs: 2400 }),
+  Object.freeze({ label: "1×", delayMs: 1500 }),
+  Object.freeze({ label: "1.5×", delayMs: 850 }),
+  Object.freeze({ label: "2×", delayMs: 350 }),
+]);
+
+export const CEREMONY_PRESETS = Object.freeze({
+  icpc: Object.freeze({
+    baseline: "auto",
+    policy: "bottom-up-sticky",
+    granularity: "cell",
+    tieOrder: "seeded",
+    speedIndex: 1,
+    pauseBeats: Object.freeze({
+      rankChange: true,
+      awardZone: true,
+      contestantFinished: true,
+      firstSolve: true,
+    }),
+  }),
+  full: Object.freeze({
+    baseline: "beginning",
+    policy: "bottom-up-sticky",
+    granularity: "cell",
+    tieOrder: "seeded",
+    speedIndex: 1,
+    pauseBeats: Object.freeze({
+      rankChange: true,
+      awardZone: true,
+      contestantFinished: true,
+      firstSolve: true,
+    }),
+  }),
+  director: Object.freeze({
+    baseline: "auto",
+    policy: "manual",
+    granularity: "cell",
+    tieOrder: "seeded",
+    speedIndex: 1,
+    pauseBeats: Object.freeze({
+      rankChange: false,
+      awardZone: false,
+      contestantFinished: false,
+      firstSolve: false,
+    }),
+  }),
+});
+
+export function clampSpeedIndex(index) {
+  return Math.max(0, Math.min(SPEED_PRESETS.length - 1, Number(index) || 0));
+}
+
+export function normalizeAwardPlaces(value, contestantCount) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+  return Math.min(parsed, Math.max(0, contestantCount));
+}
+
+export function getPauseReason(transitions, pauseBeats, awardPlaces) {
+  for (const transition of transitions) {
+    const effects = transition.effects;
+    if (
+      pauseBeats.awardZone &&
+      awardPlaces > 0 &&
+      effects.rankBefore > awardPlaces &&
+      effects.rankAfter <= awardPlaces
+    ) {
+      return `Entered the top ${awardPlaces} award zone.`;
+    }
+    if (pauseBeats.rankChange && effects.rankBefore !== effects.rankAfter) {
+      return `Rank changed from ${effects.rankBefore} to ${effects.rankAfter}.`;
+    }
+    if (pauseBeats.firstSolve && effects.firstSolveAppeared) {
+      return "A first solve appeared.";
+    }
+    if (pauseBeats.contestantFinished && effects.contestantFinished) {
+      return "Contestant fully resolved.";
+    }
+  }
+  return null;
+}
+
+function createDelay(duration) {
+  let timer = null;
+  let resolveDelay = null;
+  return {
+    promise: new Promise((resolve) => {
+      resolveDelay = resolve;
+      timer = globalThis.setTimeout(resolve, duration);
+    }),
+    cancel() {
+      if (timer !== null) {
+        globalThis.clearTimeout(timer);
+        timer = null;
+        resolveDelay();
+      }
+    },
+  };
+}
+
+export class AutoplayController {
+  constructor({ step, onChange = () => {}, speedIndex = 1 }) {
+    this.step = step;
+    this.onChange = onChange;
+    this.speedIndex = clampSpeedIndex(speedIndex);
+    this.playing = false;
+    this.pauseKind = "idle";
+    this.pauseReason = null;
+    this._runSerial = 0;
+    this._delay = null;
+  }
+
+  getState() {
+    return {
+      playing: this.playing,
+      pauseKind: this.pauseKind,
+      pauseReason: this.pauseReason,
+      speedIndex: this.speedIndex,
+      speed: SPEED_PRESETS[this.speedIndex],
+    };
+  }
+
+  setSpeed(index) {
+    this.speedIndex = clampSpeedIndex(index);
+    this.onChange(this.getState());
+    return this.getState();
+  }
+
+  slower() {
+    return this.setSpeed(this.speedIndex - 1);
+  }
+
+  faster() {
+    return this.setSpeed(this.speedIndex + 1);
+  }
+
+  play() {
+    if (this.playing) {
+      return;
+    }
+    this.playing = true;
+    this.pauseKind = null;
+    this.pauseReason = null;
+    const serial = ++this._runSerial;
+    this.onChange(this.getState());
+    void this._run(serial);
+  }
+
+  pause(reason = "Autoplay paused.", kind = "operator") {
+    this.playing = false;
+    this.pauseKind = kind;
+    this.pauseReason = reason;
+    this._runSerial += 1;
+    if (this._delay) {
+      this._delay.cancel();
+      this._delay = null;
+    }
+    this.onChange(this.getState());
+  }
+
+  toggle() {
+    if (this.playing) {
+      this.pause();
+    } else {
+      this.play();
+    }
+  }
+
+  async _run(serial) {
+    while (this.playing && serial === this._runSerial) {
+      const result = await this.step();
+      if (!this.playing || serial !== this._runSerial) {
+        return;
+      }
+      if (!result || result.complete) {
+        this.pause("Resolver complete — final standings reached.", "complete");
+        return;
+      }
+      if (result.pauseReason) {
+        this.pause(result.pauseReason, "beat");
+        return;
+      }
+      this._delay = createDelay(SPEED_PRESETS[this.speedIndex].delayMs);
+      await this._delay.promise;
+      this._delay = null;
+    }
+  }
+}

--- a/resources/resolver/core.js
+++ b/resources/resolver/core.js
@@ -59,18 +59,30 @@ function normalizeBaseline(payload, requested) {
 }
 
 function normalizeContestant(sourceContestant, tieKey) {
+  const organizations = Array.isArray(sourceContestant.organizations)
+    ? sourceContestant.organizations
+    : sourceContestant.organization
+    ? [sourceContestant.organization]
+    : [];
   return {
     participationId: sourceContestant.participation_id,
     profileId: sourceContestant.profile_id,
     username: sourceContestant.username,
     displayName: sourceContestant.display_name,
+    fullName: sourceContestant.full_name ?? "",
     cssClass: sourceContestant.user_css_class,
     profileUrl: sourceContestant.profile_url,
     avatarUrl: sourceContestant.avatar_url,
     rankLogoUrl: sourceContestant.rank_logo_url,
-    organization: clone(sourceContestant.organization),
+    organizations: clone(organizations),
     isDisqualified: sourceContestant.is_disqualified === true,
     submissionCount: sourceContestant.submission_count,
+    finalOrder: Number.isFinite(sourceContestant.final_order)
+      ? sourceContestant.final_order
+      : tieKey,
+    frozenOrder: Number.isFinite(sourceContestant.frozen_order)
+      ? sourceContestant.frozen_order
+      : tieKey,
     tieKey,
     score: 0,
     cumtime: 0,
@@ -140,10 +152,22 @@ export class ResolverSession {
   }
 
   _createInitialState() {
-    const tieKeys =
-      this.tieOrder === "source"
-        ? createSourceOrderTieKeys(this.source.contestants)
-        : createDeterministicTieKeys(this.source.contestants, this.seed);
+    let tieKeys;
+    if (this.tieOrder === "source") {
+      tieKeys = createSourceOrderTieKeys(this.source.contestants);
+    } else if (
+      this.baseline === "official-freeze" &&
+      this.source.contestants.every((contestant) => Number.isFinite(contestant.frozen_order))
+    ) {
+      tieKeys = new Map(
+        this.source.contestants.map((contestant) => [
+          String(contestant.participation_id),
+          contestant.frozen_order,
+        ]),
+      );
+    } else {
+      tieKeys = createDeterministicTieKeys(this.source.contestants, this.seed);
+    }
     const contestants = this.source.contestants.map((sourceContestant) => {
       const contestantId = String(sourceContestant.participation_id);
       const contestant = normalizeContestant(sourceContestant, tieKeys.get(contestantId));
@@ -160,17 +184,20 @@ export class ResolverSession {
       return contestant;
     });
 
-    return {
-      contestants,
-      standings: rankContestants(contestants),
-    };
+    const state = { contestants, standings: [] };
+    this._rerankState(state);
+    return state;
+  }
+
+  _findContestantInState(state, contestantId) {
+    const normalized = String(contestantId);
+    return state.contestants.find(
+      (contestant) => String(contestant.participationId) === normalized,
+    );
   }
 
   _findContestant(contestantId) {
-    const normalized = String(contestantId);
-    return this._state.contestants.find(
-      (contestant) => String(contestant.participationId) === normalized,
-    );
+    return this._findContestantInState(this._state, contestantId);
   }
 
   _isFullyResolved(contestant) {
@@ -194,8 +221,18 @@ export class ResolverSession {
     contestant.tiebreaker = metrics.tiebreaker;
   }
 
+  _isStateFullyResolved(state) {
+    return state.contestants.every((contestant) => this._isFullyResolved(contestant));
+  }
+
+  _rerankState(state) {
+    state.standings = rankContestants(state.contestants, {
+      fallback: this._isStateFullyResolved(state) ? "finalOrder" : "tieKey",
+    });
+  }
+
   _rerank() {
-    this._state.standings = rankContestants(this._state.contestants);
+    this._rerankState(this._state);
   }
 
   getState() {
@@ -222,48 +259,52 @@ export class ResolverSession {
     return cells;
   }
 
-  revealCell(contestantId, problemId) {
-    const contestant = this._findContestant(contestantId);
-    if (!contestant) {
-      throw new RangeError(`Unknown Resolver contestant "${contestantId}".`);
-    }
+  _projectReveal(contestantId, problemId) {
     const normalizedProblemId = String(problemId);
     if (!this._problems.has(normalizedProblemId)) {
       throw new RangeError(`Unknown Resolver problem "${problemId}".`);
     }
 
+    const before = clone(this._state);
+    const contestant = this._findContestantInState(before, contestantId);
+    if (!contestant) {
+      throw new RangeError(`Unknown Resolver contestant "${contestantId}".`);
+    }
     const currentCell = contestant.problems[normalizedProblemId];
     if (!this.adapter.isResolvable(currentCell)) {
       return null;
     }
 
-    if (this._historyCursor < this._history.length) {
-      this._history.splice(this._historyCursor);
-    }
-    const before = clone(this._state);
     const beforeStanding = before.standings.find(
       (standing) => String(standing.contestantId) === String(contestant.participationId),
     );
-    const firstSolveExisted = before.contestants.some(
-      (entry) => entry.problems[normalizedProblemId]?.state === "solved",
-    );
     const topBefore = before.standings[0]?.contestantId ?? null;
+    const beforeScore = contestant.score;
+    const beforePoints = currentCell.points;
 
-    contestant.problems[normalizedProblemId] = this.adapter.revealCell(
-      currentCell,
+    const after = clone(before);
+    const afterContestant = this._findContestantInState(after, contestant.participationId);
+    afterContestant.problems[normalizedProblemId] = this.adapter.revealCell(
+      afterContestant.problems[normalizedProblemId],
       this._finalCells[String(contestant.participationId)][normalizedProblemId],
     );
-    this._recomputeContestant(contestant);
-    this._rerank();
+    this._recomputeContestant(afterContestant);
+    this._rerankState(after);
 
-    const after = clone(this._state);
     const afterStanding = after.standings.find(
       (standing) => String(standing.contestantId) === String(contestant.participationId),
     );
-    const revealedCell = contestant.problems[normalizedProblemId];
+    const revealedCell = afterContestant.problems[normalizedProblemId];
+    const authoritativeFirstSolveId =
+      this._problems.get(normalizedProblemId).first_solve_participation_id ?? null;
+    const authoritativeFirstSolveAppeared =
+      authoritativeFirstSolveId !== null &&
+      String(authoritativeFirstSolveId) === String(contestant.participationId) &&
+      revealedCell.state === "solved";
     const topAfter = after.standings[0]?.contestantId ?? null;
-    const transition = {
-      id: `reveal-${++this._transitionSerial}`,
+
+    return {
+      id: null,
       type: "reveal-cell",
       target: {
         contestantId: contestant.participationId,
@@ -276,11 +317,31 @@ export class ResolverSession {
         positionAfter: afterStanding.position,
         rankBefore: beforeStanding.rank,
         rankAfter: afterStanding.rank,
-        contestantFinished: this._isFullyResolved(contestant),
+        contestantFinished: this._isFullyResolved(afterContestant),
         topChanged: String(topBefore) !== String(topAfter),
-        firstSolveAppeared: !firstSolveExisted && revealedCell.state === "solved",
+        scoreImproved: afterContestant.score > beforeScore,
+        cellPointsImproved: revealedCell.points > beforePoints,
+        authoritativeFirstSolveAppeared,
+        firstSolveAppeared: authoritativeFirstSolveAppeared,
       },
     };
+  }
+
+  projectReveal(contestantId, problemId) {
+    return clone(this._projectReveal(contestantId, problemId));
+  }
+
+  revealCell(contestantId, problemId) {
+    const transition = this._projectReveal(contestantId, problemId);
+    if (!transition) {
+      return null;
+    }
+
+    if (this._historyCursor < this._history.length) {
+      this._history.splice(this._historyCursor);
+    }
+    transition.id = `reveal-${++this._transitionSerial}`;
+    this._state = clone(transition.after);
     this._history.push(transition);
     this._historyCursor += 1;
     return clone(transition);

--- a/resources/resolver/core.js
+++ b/resources/resolver/core.js
@@ -1,0 +1,318 @@
+import { DefaultAdapter } from "./formats/default.js";
+import { ICPCAdapter } from "./formats/icpc.js";
+import { VNOJAdapter } from "./formats/vnoj.js";
+import {
+  createDeterministicTieKeys,
+  createSourceOrderTieKeys,
+  rankContestants,
+} from "./ranking.js";
+import { clone, deepFreeze } from "./utils.js";
+
+const ADAPTERS = Object.freeze({
+  default: DefaultAdapter,
+  icpc: ICPCAdapter,
+  vnoj: VNOJAdapter,
+});
+
+export class UnsupportedResolverFormatError extends Error {
+  constructor(formatName) {
+    super(`Contest format "${formatName}" is not supported by Resolver.`);
+    this.name = "UnsupportedResolverFormatError";
+    this.formatName = formatName;
+  }
+}
+
+export class UnsupportedResolverBaselineError extends Error {
+  constructor(baseline) {
+    super(`Resolver baseline "${baseline}" is not available for this contest.`);
+    this.name = "UnsupportedResolverBaselineError";
+    this.baseline = baseline;
+  }
+}
+
+function validatePayload(payload) {
+  if (
+    !payload ||
+    payload.schema_version !== 1 ||
+    !payload.contest ||
+    !Array.isArray(payload.problems) ||
+    !Array.isArray(payload.contestants)
+  ) {
+    throw new TypeError("Invalid Resolver schema version 1 payload.");
+  }
+}
+
+function normalizeBaseline(payload, requested) {
+  const baseline =
+    requested === "auto"
+      ? payload.contest.official_freeze_available
+        ? "official-freeze"
+        : "beginning"
+      : requested;
+  if (baseline !== "beginning" && baseline !== "official-freeze") {
+    throw new UnsupportedResolverBaselineError(baseline);
+  }
+  if (baseline === "official-freeze" && !payload.contest.official_freeze_available) {
+    throw new UnsupportedResolverBaselineError(baseline);
+  }
+  return baseline;
+}
+
+function normalizeContestant(sourceContestant, tieKey) {
+  return {
+    participationId: sourceContestant.participation_id,
+    profileId: sourceContestant.profile_id,
+    username: sourceContestant.username,
+    displayName: sourceContestant.display_name,
+    cssClass: sourceContestant.user_css_class,
+    profileUrl: sourceContestant.profile_url,
+    avatarUrl: sourceContestant.avatar_url,
+    rankLogoUrl: sourceContestant.rank_logo_url,
+    organization: clone(sourceContestant.organization),
+    isDisqualified: sourceContestant.is_disqualified === true,
+    submissionCount: sourceContestant.submission_count,
+    tieKey,
+    score: 0,
+    cumtime: 0,
+    tiebreaker: 0,
+    problems: {},
+  };
+}
+
+export class ResolverSession {
+  constructor(payload, options = {}) {
+    validatePayload(payload);
+    this.source = deepFreeze(clone(payload));
+
+    const formatName = this.source.contest.format;
+    this.adapter = ADAPTERS[formatName];
+    if (!this.adapter) {
+      throw new UnsupportedResolverFormatError(formatName);
+    }
+
+    this.baseline = normalizeBaseline(this.source, options.baseline ?? "auto");
+    this.tieOrder = options.tieOrder ?? "seeded";
+    if (this.tieOrder !== "seeded" && this.tieOrder !== "source") {
+      throw new TypeError(`Unknown Resolver tie order "${this.tieOrder}".`);
+    }
+    const defaultSeed = `${this.source.contest.key}:${this.source.contestants
+      .map((contestant) => contestant.participation_id)
+      .sort()
+      .join(",")}`;
+    this.seed = String(options.seed ?? defaultSeed);
+    this._sourceContestants = new Map(
+      this.source.contestants.map((contestant) => [
+        String(contestant.participation_id),
+        contestant,
+      ]),
+    );
+    this._orderedProblems = Object.freeze(
+      [...this.source.problems].sort(
+        (left, right) =>
+          left.order - right.order || String(left.id).localeCompare(String(right.id)),
+      ),
+    );
+    this._problems = new Map(this._orderedProblems.map((problem) => [String(problem.id), problem]));
+    this._finalCells = this._buildFinalCells();
+    this._transitionSerial = 0;
+    this._history = [];
+    this._historyCursor = 0;
+
+    const initial = this._createInitialState();
+    this._baselineState = deepFreeze(clone(initial));
+    this._state = clone(initial);
+  }
+
+  _buildFinalCells() {
+    const finalCells = {};
+    this.source.contestants.forEach((contestant) => {
+      const contestantId = String(contestant.participation_id);
+      finalCells[contestantId] = {};
+      this._orderedProblems.forEach((problem) => {
+        const problemId = String(problem.id);
+        const payloadCell = contestant.problems[problemId] ?? null;
+        finalCells[contestantId][problemId] = deepFreeze(
+          this.adapter.createFinalCell(problem, payloadCell),
+        );
+      });
+    });
+    return deepFreeze(finalCells);
+  }
+
+  _createInitialState() {
+    const tieKeys =
+      this.tieOrder === "source"
+        ? createSourceOrderTieKeys(this.source.contestants)
+        : createDeterministicTieKeys(this.source.contestants, this.seed);
+    const contestants = this.source.contestants.map((sourceContestant) => {
+      const contestantId = String(sourceContestant.participation_id);
+      const contestant = normalizeContestant(sourceContestant, tieKeys.get(contestantId));
+
+      this._orderedProblems.forEach((problem) => {
+        const problemId = String(problem.id);
+        const payloadCell = sourceContestant.problems[problemId] ?? null;
+        contestant.problems[problemId] =
+          this.baseline === "beginning"
+            ? this.adapter.createBeginningCell(problem, payloadCell)
+            : this.adapter.createFrozenCell(problem, payloadCell);
+      });
+      this._recomputeContestant(contestant);
+      return contestant;
+    });
+
+    return {
+      contestants,
+      standings: rankContestants(contestants),
+    };
+  }
+
+  _findContestant(contestantId) {
+    const normalized = String(contestantId);
+    return this._state.contestants.find(
+      (contestant) => String(contestant.participationId) === normalized,
+    );
+  }
+
+  _isFullyResolved(contestant) {
+    return Object.values(contestant.problems).every((cell) => !this.adapter.isResolvable(cell));
+  }
+
+  _recomputeContestant(contestant) {
+    const metrics = this.adapter.recomputeContestant(
+      contestant,
+      contestant.problems,
+      this.source.contest.format_config,
+      this.source.contest.points_precision,
+    );
+
+    if (contestant.isDisqualified && this._isFullyResolved(contestant)) {
+      const sourceContestant = this._sourceContestants.get(String(contestant.participationId));
+      Object.assign(metrics, sourceContestant.final);
+    }
+    contestant.score = metrics.score;
+    contestant.cumtime = metrics.cumtime;
+    contestant.tiebreaker = metrics.tiebreaker;
+  }
+
+  _rerank() {
+    this._state.standings = rankContestants(this._state.contestants);
+  }
+
+  getState() {
+    return clone(this._state);
+  }
+
+  getHistory() {
+    return clone({ cursor: this._historyCursor, transitions: this._history });
+  }
+
+  getResolvableCells() {
+    const cells = [];
+    this._state.contestants.forEach((contestant) => {
+      this._orderedProblems.forEach((problem) => {
+        const problemId = String(problem.id);
+        if (this.adapter.isResolvable(contestant.problems[problemId])) {
+          cells.push({
+            contestantId: contestant.participationId,
+            problemId: problem.id,
+          });
+        }
+      });
+    });
+    return cells;
+  }
+
+  revealCell(contestantId, problemId) {
+    const contestant = this._findContestant(contestantId);
+    if (!contestant) {
+      throw new RangeError(`Unknown Resolver contestant "${contestantId}".`);
+    }
+    const normalizedProblemId = String(problemId);
+    if (!this._problems.has(normalizedProblemId)) {
+      throw new RangeError(`Unknown Resolver problem "${problemId}".`);
+    }
+
+    const currentCell = contestant.problems[normalizedProblemId];
+    if (!this.adapter.isResolvable(currentCell)) {
+      return null;
+    }
+
+    if (this._historyCursor < this._history.length) {
+      this._history.splice(this._historyCursor);
+    }
+    const before = clone(this._state);
+    const beforeStanding = before.standings.find(
+      (standing) => String(standing.contestantId) === String(contestant.participationId),
+    );
+    const firstSolveExisted = before.contestants.some(
+      (entry) => entry.problems[normalizedProblemId]?.state === "solved",
+    );
+    const topBefore = before.standings[0]?.contestantId ?? null;
+
+    contestant.problems[normalizedProblemId] = this.adapter.revealCell(
+      currentCell,
+      this._finalCells[String(contestant.participationId)][normalizedProblemId],
+    );
+    this._recomputeContestant(contestant);
+    this._rerank();
+
+    const after = clone(this._state);
+    const afterStanding = after.standings.find(
+      (standing) => String(standing.contestantId) === String(contestant.participationId),
+    );
+    const revealedCell = contestant.problems[normalizedProblemId];
+    const topAfter = after.standings[0]?.contestantId ?? null;
+    const transition = {
+      id: `reveal-${++this._transitionSerial}`,
+      type: "reveal-cell",
+      target: {
+        contestantId: contestant.participationId,
+        problemId: this._problems.get(normalizedProblemId).id,
+      },
+      before,
+      after,
+      effects: {
+        positionBefore: beforeStanding.position,
+        positionAfter: afterStanding.position,
+        rankBefore: beforeStanding.rank,
+        rankAfter: afterStanding.rank,
+        contestantFinished: this._isFullyResolved(contestant),
+        topChanged: String(topBefore) !== String(topAfter),
+        firstSolveAppeared: !firstSolveExisted && revealedCell.state === "solved",
+      },
+    };
+    this._history.push(transition);
+    this._historyCursor += 1;
+    return clone(transition);
+  }
+
+  back() {
+    if (this._historyCursor === 0) {
+      return false;
+    }
+    this._historyCursor -= 1;
+    this._state = clone(this._history[this._historyCursor].before);
+    return true;
+  }
+
+  forward() {
+    if (this._historyCursor >= this._history.length) {
+      return false;
+    }
+    this._state = clone(this._history[this._historyCursor].after);
+    this._historyCursor += 1;
+    return true;
+  }
+
+  reset() {
+    this._state = clone(this._baselineState);
+    this._history = [];
+    this._historyCursor = 0;
+    this._transitionSerial = 0;
+    return this.getState();
+  }
+
+  replay() {
+    return this.reset();
+  }
+}

--- a/resources/resolver/formats/default.js
+++ b/resources/resolver/formats/default.js
@@ -1,0 +1,41 @@
+import { cellState, clone, hiddenCell, roundLikePython } from "../utils.js";
+
+export const DefaultAdapter = Object.freeze({
+  name: "default",
+
+  createFinalCell(problem, payloadCell) {
+    return cellState(problem, payloadCell ? payloadCell.final : null);
+  },
+
+  createBeginningCell(problem, payloadCell) {
+    return payloadCell ? hiddenCell() : cellState(problem, null);
+  },
+
+  createFrozenCell() {
+    throw new Error("The default contest format has no official-freeze baseline.");
+  },
+
+  isResolvable(currentCell) {
+    return currentCell.attempted && !currentCell.revealed;
+  },
+
+  revealCell(currentCell, finalCell) {
+    return this.isResolvable(currentCell) ? clone(finalCell) : clone(currentCell);
+  },
+
+  recomputeContestant(contestant, problemStates, contestConfig, pointsPrecision) {
+    let score = 0;
+    let cumtime = 0;
+    Object.values(problemStates).forEach((cell) => {
+      score += cell.points;
+      if (cell.points !== 0) {
+        cumtime += cell.time;
+      }
+    });
+    return {
+      score: roundLikePython(score, pointsPrecision),
+      cumtime: Math.trunc(Math.max(cumtime, 0)),
+      tiebreaker: 0,
+    };
+  },
+});

--- a/resources/resolver/formats/icpc.js
+++ b/resources/resolver/formats/icpc.js
@@ -1,0 +1,54 @@
+import { cellState, clone, hiddenCell, numeric, roundLikePython } from "../utils.js";
+
+export const ICPCAdapter = Object.freeze({
+  name: "icpc",
+
+  createFinalCell(problem, payloadCell) {
+    return cellState(problem, payloadCell ? payloadCell.final : null);
+  },
+
+  createBeginningCell(problem, payloadCell) {
+    return payloadCell ? hiddenCell() : cellState(problem, null);
+  },
+
+  createFrozenCell(problem, payloadCell) {
+    if (!payloadCell || !payloadCell.frozen || !payloadCell.frozen.pending) {
+      return this.createFinalCell(problem, payloadCell);
+    }
+    return cellState(problem, payloadCell.frozen, {
+      state: "pending",
+      revealed: false,
+    });
+  },
+
+  isResolvable(currentCell) {
+    return currentCell.attempted && !currentCell.revealed;
+  },
+
+  revealCell(currentCell, finalCell) {
+    return this.isResolvable(currentCell) ? clone(finalCell) : clone(currentCell);
+  },
+
+  recomputeContestant(contestant, problemStates, contestConfig, pointsPrecision) {
+    const penaltyMinutes = numeric(contestConfig.penalty, 20);
+    let score = 0;
+    let cumtime = 0;
+    let tiebreaker = 0;
+
+    Object.values(problemStates).forEach((cell) => {
+      if (cell.points === 0) {
+        return;
+      }
+      const minute = Math.floor(cell.time / 60);
+      score += cell.points;
+      cumtime += minute + (numeric(cell.tries) - 1) * penaltyMinutes;
+      tiebreaker = Math.max(tiebreaker, minute);
+    });
+
+    return {
+      score: roundLikePython(score, pointsPrecision),
+      cumtime: Math.max(cumtime, 0),
+      tiebreaker,
+    };
+  },
+});

--- a/resources/resolver/formats/vnoj.js
+++ b/resources/resolver/formats/vnoj.js
@@ -1,0 +1,62 @@
+import { cellState, clone, hiddenCell, numeric, roundLikePython } from "../utils.js";
+
+export const VNOJAdapter = Object.freeze({
+  name: "vnoj",
+
+  createFinalCell(problem, payloadCell) {
+    return cellState(problem, payloadCell ? payloadCell.final : null, { pending: 0 });
+  },
+
+  createBeginningCell(problem, payloadCell) {
+    return payloadCell ? hiddenCell() : cellState(problem, null);
+  },
+
+  createFrozenCell(problem, payloadCell) {
+    if (
+      !payloadCell ||
+      !payloadCell.frozen ||
+      !payloadCell.frozen.pending ||
+      numeric(payloadCell.frozen.points) === numeric(problem.max_score)
+    ) {
+      return this.createFinalCell(problem, payloadCell);
+    }
+    return cellState(problem, payloadCell.frozen, {
+      state: "pending",
+      revealed: false,
+    });
+  },
+
+  isResolvable(currentCell) {
+    return currentCell.attempted && !currentCell.revealed;
+  },
+
+  revealCell(currentCell, finalCell) {
+    return this.isResolvable(currentCell) ? clone(finalCell) : clone(currentCell);
+  },
+
+  recomputeContestant(contestant, problemStates, contestConfig, pointsPrecision) {
+    const penaltyMinutes = numeric(contestConfig.penalty, 5);
+    const lastSubmissionOnly = contestConfig.LSO === true;
+    let score = 0;
+    let summedTime = 0;
+    let penaltySeconds = 0;
+    let tiebreaker = 0;
+
+    Object.values(problemStates).forEach((cell) => {
+      score += cell.points;
+      if (cell.points === 0) {
+        return;
+      }
+      summedTime += cell.time;
+      tiebreaker = Math.max(tiebreaker, cell.time);
+      penaltySeconds += numeric(cell.penalty) * penaltyMinutes * 60;
+    });
+
+    const scoringTime = lastSubmissionOnly ? tiebreaker : summedTime;
+    return {
+      score: roundLikePython(score, pointsPrecision),
+      cumtime: Math.trunc(Math.max(scoringTime + penaltySeconds, 0)),
+      tiebreaker,
+    };
+  },
+});

--- a/resources/resolver/page.js
+++ b/resources/resolver/page.js
@@ -1,13 +1,28 @@
 import { animateChangedCells, animateRows, captureRowPositions } from "./animation.js";
 import {
-  AutoplayController,
   CEREMONY_PRESETS,
-  getPauseReason,
+  SPEED_PRESETS,
+  clampSpeedIndex,
   normalizeAwardPlaces,
+  normalizeSingleStepStartRank,
 } from "./controller.js";
 import { ResolverSession } from "./core.js";
-import { BottomUpStickyPolicy, ByContestantPolicy, ByProblemPolicy } from "./policies.js";
-import { deriveProblemStats, getCellPresentation, getMetricPresentation } from "./presentation.js";
+import { ResolutionPlanner } from "./planner.js";
+import { ResolutionPlayer } from "./player.js";
+import {
+  BottomUpStickyPolicy,
+  ByContestantPolicy,
+  ByProblemPolicy,
+  RowSweepPolicy,
+} from "./policies.js";
+import {
+  deriveProblemStats,
+  getCellPresentation,
+  getMetricPresentation,
+  getOrganizationPresentation,
+  normalizeRankDisplayOption,
+} from "./presentation.js";
+import { RESOLUTION_STEP_TYPES } from "./timing.js";
 
 function element(tagName, className = "", text = null) {
   const node = document.createElement(tagName);
@@ -32,6 +47,7 @@ function isTypingTarget(target) {
 }
 
 const POLICY_LABELS = Object.freeze({
+  "row-sweep": "ICPC row sweep",
   "bottom-up-sticky": "Bottom-up",
   "by-problem": "By problem",
   "by-contestant": "By contestant",
@@ -46,11 +62,15 @@ export class ResolverPage {
       (left, right) => left.order - right.order || String(left.id).localeCompare(String(right.id)),
     );
     this.session = null;
-    this.policy = new BottomUpStickyPolicy();
-    this.policyName = "bottom-up-sticky";
+    this.policy = new RowSweepPolicy(this.problems.map((problem) => problem.id));
+    this.policyName = "row-sweep";
     this.granularity = "cell";
-    this.pauseBeats = { ...CEREMONY_PRESETS.icpc.pauseBeats };
-    this.awardPlaces = Math.min(3, payload.contestants.length);
+    this.hardPauses = { ...CEREMONY_PRESETS.icpc.hardPauses };
+    this.awardPlaces = Math.min(6, payload.contestants.length);
+    this.singleStepStartRank = Math.min(6, payload.contestants.length);
+    this.speedIndex = 1;
+    this.planner = null;
+    this.player = null;
     this.busy = false;
     this.totalResolvable = 0;
     this.hudVisible = true;
@@ -68,16 +88,14 @@ export class ResolverPage {
       tieOrder: root.querySelector("#resolver-tie-order"),
       speed: root.querySelector("#resolver-speed"),
       awardPlaces: root.querySelector("#resolver-award-places"),
-      pauseRank: root.querySelector('[name="pause_rank"]'),
+      singleStepStartRank: root.querySelector("#resolver-single-step-start-rank"),
       pauseAward: root.querySelector('[name="pause_award"]'),
-      pauseFinished: root.querySelector('[name="pause_finished"]'),
       pauseFirstSolve: root.querySelector('[name="pause_first_solve"]'),
       freezeNote: root.querySelector("#resolver-freeze-note"),
       workspace: root.querySelector("#resolver-workspace"),
       table: root.querySelector("#ranking-table"),
       tableHead: root.querySelector("#resolver-table-head"),
       tableBody: root.querySelector("#resolver-table-body"),
-      tableFoot: root.querySelector("#resolver-table-foot"),
       status: root.querySelector("#resolver-status"),
       progress: root.querySelector("#resolver-progress"),
       next: root.querySelector("#resolver-next"),
@@ -98,15 +116,15 @@ export class ResolverPage {
       hudTarget: root.querySelector("#resolver-hud-target"),
       hudHistory: root.querySelector("#resolver-hud-history"),
       hudAward: root.querySelector("#resolver-hud-award"),
+      hudCurrentPosition: root.querySelector("#resolver-hud-current-position"),
+      hudAfterPosition: root.querySelector("#resolver-hud-after-position"),
+      hudMovement: root.querySelector("#resolver-hud-movement"),
+      hudZone: root.querySelector("#resolver-hud-zone"),
+      hudRemaining: root.querySelector("#resolver-hud-remaining"),
       hudSeed: root.querySelector("#resolver-hud-seed"),
       shortcuts: root.querySelector("#resolver-shortcuts"),
       shortcutsClose: root.querySelector("#resolver-shortcuts-close"),
     };
-    this.autoplay = new AutoplayController({
-      step: () => this._autoplayStep(),
-      onChange: (state) => this._onAutoplayChange(state),
-      speedIndex: 1,
-    });
   }
 
   mount() {
@@ -125,6 +143,8 @@ export class ResolverPage {
     freezeOption.disabled = !freezeAvailable;
     this.nodes.awardPlaces.max = String(this.payload.contestants.length);
     this.nodes.awardPlaces.value = String(this.awardPlaces);
+    this.nodes.singleStepStartRank.max = String(this.payload.contestants.length);
+    this.nodes.singleStepStartRank.value = String(this.singleStepStartRank);
     this.nodes.freezeNote.textContent = freezeAvailable
       ? `Official freeze is available (${this.payload.contest.frozen_last_minutes} minutes).`
       : "This format has no native official-freeze state; Auto uses Beginning.";
@@ -144,20 +164,27 @@ export class ResolverPage {
         this._renderPresetSelection();
       }
     });
-    this.nodes.next.addEventListener("click", () => this._stepFromOperator("Next control"));
-    this.nodes.play.addEventListener("click", () => this._toggleAutoplay());
-    this.nodes.slower.addEventListener("click", () => this.autoplay.slower());
-    this.nodes.faster.addEventListener("click", () => this.autoplay.faster());
+    this.nodes.next.addEventListener("click", () => void this._playToNextPause(true));
+    this.nodes.play.addEventListener("click", () => this._togglePlayback());
+    this.nodes.slower.addEventListener("click", () => this._changeSpeed(-1));
+    this.nodes.faster.addEventListener("click", () => this._changeSpeed(1));
     this.nodes.back.addEventListener("click", () => {
-      this._pauseAutoplay();
-      void this._moveHistory("back");
+      this._pausePlayback();
+      if (this.policyName === "manual") {
+        void this._moveHistory("back");
+      } else {
+        void this.player?.rewindToPreviousPause();
+      }
     });
     this.nodes.forward.addEventListener("click", () => {
-      this._pauseAutoplay();
-      void this._moveHistory("forward");
+      if (this.policyName === "manual") {
+        void this._moveHistory("forward");
+      } else {
+        void this._playToNextPause(false);
+      }
     });
     this.nodes.reset.addEventListener("click", () => {
-      this._pauseAutoplay();
+      this._pausePlayback();
       void this._reset(false);
     });
     this.nodes.replay.addEventListener("click", () => void this._replay());
@@ -172,28 +199,35 @@ export class ResolverPage {
     this.nodes.fullscreen.addEventListener("click", () => void this._toggleFullscreen());
     this.nodes.changeSetup.addEventListener("click", () => this._showSetup());
     this.nodes.tableBody.addEventListener("click", (event) => {
-      const button = event.target.closest("button[data-resolver-action]");
-      if (!button || this.busy) {
+      const action = event.target.closest("[data-resolver-action]");
+      if (!action || event.target.closest("a") || this.busy) {
         return;
       }
-      this._pauseAutoplay("Autoplay paused for a manual reveal.");
+      this._pausePlayback("Playback paused for a manual reveal.");
       this.policy.clear();
-      if (button.dataset.resolverAction === "reveal-cell") {
+      if (action.dataset.resolverAction === "reveal-cell") {
         void this._revealTargets(
           [
             {
-              contestantId: button.dataset.contestantId,
-              problemId: button.dataset.problemId,
+              contestantId: action.dataset.contestantId,
+              problemId: action.dataset.problemId,
             },
           ],
           "Manual cell reveal",
         );
-      } else if (button.dataset.resolverAction === "reveal-contestant") {
-        void this._revealContestant(button.dataset.contestantId, "Manual contestant reveal");
+      } else if (action.dataset.resolverAction === "reveal-contestant") {
+        void this._revealContestant(action.dataset.contestantId, "Manual contestant reveal");
+      }
+    });
+    this.nodes.tableBody.addEventListener("keydown", (event) => {
+      const action = event.target.closest('[data-resolver-action="reveal-contestant"]');
+      if (action && (event.key === "Enter" || event.key === " ")) {
+        event.preventDefault();
+        action.click();
       }
     });
     document.addEventListener("keydown", (event) => this._handleShortcut(event));
-    document.addEventListener("fullscreenchange", () => this._renderControls(this._selectTarget()));
+    document.addEventListener("fullscreenchange", () => this._renderControls());
   }
 
   _applyPreset(name) {
@@ -207,11 +241,16 @@ export class ResolverPage {
     this.nodes.granularity.value = preset.granularity;
     this.nodes.tieOrder.value = preset.tieOrder;
     this.nodes.speed.value = String(preset.speedIndex);
-    this.nodes.pauseRank.checked = preset.pauseBeats.rankChange;
-    this.nodes.pauseAward.checked = preset.pauseBeats.awardZone;
-    this.nodes.pauseFinished.checked = preset.pauseBeats.contestantFinished;
-    this.nodes.pauseFirstSolve.checked = preset.pauseBeats.firstSolve;
-    this.autoplay.setSpeed(preset.speedIndex);
+    this.nodes.awardPlaces.value = String(
+      Math.min(preset.awardPlaces, this.payload.contestants.length),
+    );
+    this.nodes.singleStepStartRank.value = String(
+      Math.min(preset.singleStepStartRank, this.payload.contestants.length),
+    );
+    this.nodes.pauseAward.checked = preset.hardPauses.award;
+    this.nodes.pauseFirstSolve.checked = preset.hardPauses.firstSolve;
+    this.speedIndex = preset.speedIndex;
+    this.player?.setSpeed(SPEED_PRESETS[this.speedIndex].speed);
     this._renderPresetSelection();
   }
 
@@ -225,7 +264,7 @@ export class ResolverPage {
   }
 
   _start() {
-    this._pauseAutoplay();
+    this._pausePlayback();
     try {
       this.session = new ResolverSession(this.payload, {
         baseline: this.nodes.baseline.value,
@@ -244,13 +283,36 @@ export class ResolverPage {
       this.payload.contestants.length,
     );
     this.nodes.awardPlaces.value = String(this.awardPlaces);
-    this.pauseBeats = {
-      rankChange: this.nodes.pauseRank.checked,
-      awardZone: this.nodes.pauseAward.checked,
-      contestantFinished: this.nodes.pauseFinished.checked,
+    this.singleStepStartRank = normalizeSingleStepStartRank(
+      this.nodes.singleStepStartRank.value,
+      this.payload.contestants.length,
+    );
+    this.nodes.singleStepStartRank.value = String(this.singleStepStartRank);
+    this.hardPauses = {
+      singleStep: true,
+      award: this.nodes.pauseAward.checked,
       firstSolve: this.nodes.pauseFirstSolve.checked,
     };
-    this.autoplay.setSpeed(Number(this.nodes.speed.value));
+    this.speedIndex = clampSpeedIndex(Number(this.nodes.speed.value));
+    this.planner = new ResolutionPlanner({
+      payload: this.payload,
+      targetSelector: (session) => this.policy.select(session),
+      singleStepStartRank: this.singleStepStartRank,
+      awardPlaces: this.awardPlaces,
+      hardPauses: this.hardPauses,
+    });
+    this.player =
+      this.policyName === "manual"
+        ? null
+        : new ResolutionPlayer({
+            session: this.session,
+            planner: this.planner,
+            playbackSpeed: SPEED_PRESETS[this.speedIndex].speed,
+            onBeforeStep: (step) => this._beforePlayerStep(step),
+            onStep: (step, context) => this._performPlayerStep(step, context),
+            onRestore: () => this._restorePlayerView(),
+            onChange: (state) => this._onPlayerChange(state),
+          });
     this.totalResolvable = this.session.getResolvableCells().length;
     this.statusMessage = `Started from ${this._baselineLabel()}.`;
     this.nodes.setup.hidden = true;
@@ -261,6 +323,12 @@ export class ResolverPage {
   }
 
   _createPolicy(name) {
+    if (name === "row-sweep") {
+      return new RowSweepPolicy(
+        this.problems.map((problem) => problem.id),
+        this.payload.contest.predetermined_problem_choices ?? {},
+      );
+    }
     if (name === "by-problem") {
       return new ByProblemPolicy(this.problems.map((problem) => problem.id));
     }
@@ -274,7 +342,7 @@ export class ResolverPage {
     if (this.busy) {
       return;
     }
-    this._pauseAutoplay();
+    this._pausePlayback();
     this.nodes.workspace.hidden = true;
     this.nodes.setup.hidden = false;
     this.nodes.baseline.focus();
@@ -334,32 +402,38 @@ export class ResolverPage {
     );
     const stats = deriveProblemStats(this.payload, state);
     const statsByProblem = new Map(stats.map((stat) => [normalizedId(stat.problemId), stat]));
-    const nextTarget = this._selectTarget();
+    const presentation = this.player?.getState().presentation ?? {};
+    const activeSelection = presentation.selectedContestantId
+      ? {
+          contestantId: presentation.selectedContestantId,
+          problemId: presentation.selectedProblemId,
+          resultType: presentation.resultType,
+        }
+      : null;
     const rows = state.standings.map((standing) => {
       const contestant = contestants.get(normalizedId(standing.contestantId));
-      return this._renderContestantRow(contestant, standing, statsByProblem, nextTarget);
+      return this._renderContestantRow(contestant, standing, statsByProblem, activeSelection);
     });
-    this.nodes.tableBody.replaceChildren(...rows);
-    this._renderTotals(stats);
-    this._renderControls(nextTarget);
+    this.nodes.tableBody.replaceChildren(...rows, this._renderTotals(stats));
+    this._renderControls();
   }
 
-  _renderContestantRow(contestant, standing, statsByProblem, nextTarget) {
+  _renderContestantRow(contestant, standing, statsByProblem, activeSelection) {
     const row = element("tr", "resolver-row");
     row.dataset.contestantId = contestant.participationId;
     if (contestant.isDisqualified) {
       row.classList.add("resolver-row--disqualified", "disqualified");
-    } else if (this.awardPlaces > 0 && standing.rank <= this.awardPlaces) {
-      row.classList.add("resolver-row--award");
-      if (standing.rank === 1) {
-        row.classList.add("resolver-row--award-first");
-      }
     }
     if (
-      nextTarget &&
-      normalizedId(nextTarget.contestantId) === normalizedId(contestant.participationId)
+      activeSelection &&
+      normalizedId(activeSelection.contestantId) === normalizedId(contestant.participationId)
     ) {
       row.classList.add("resolver-row--target");
+      if (activeSelection.resultType) {
+        row.classList.add(
+          `resolver-row--${activeSelection.resultType.toLowerCase().replaceAll("_", "-")}`,
+        );
+      }
     }
 
     const rank = element("td", "resolver-rank ranking-column");
@@ -369,17 +443,27 @@ export class ResolverPage {
     contestantCell.dataset.label = "Contestant";
     const layout = element("div", "resolver-contestant__layout");
     const identity = element("div", "usr-ranking-left resolver-contestant__identity");
-    const rankDisplayOptions = Number(this.payload.contest.rank_display_options ?? 1);
-    if (rankDisplayOptions !== 3) {
-      const visual = element("div", "u-logo-ranking");
+    const rankDisplayOptions = normalizeRankDisplayOption(
+      this.payload.contest.rank_display_options,
+    );
+    if (rankDisplayOptions === 1 || rankDisplayOptions === 2) {
+      const visual = element(
+        "div",
+        `u-logo-ranking resolver-contestant__visual resolver-contestant__visual--${
+          rankDisplayOptions === 1 ? "avatar" : "logo"
+        }`,
+      );
       const visualUrl = rankDisplayOptions === 2 ? contestant.rankLogoUrl : contestant.avatarUrl;
       if (visualUrl) {
-        const avatar = element("img", "resolver-contestant__avatar");
-        avatar.src = visualUrl;
-        avatar.alt = "";
-        avatar.width = 64;
-        avatar.height = 64;
-        visual.append(avatar);
+        const image = element(
+          "img",
+          rankDisplayOptions === 1 ? "resolver-contestant__avatar" : "resolver-contestant__logo",
+        );
+        image.src = visualUrl;
+        image.alt = "";
+        image.width = 64;
+        image.height = 64;
+        visual.append(image);
       } else {
         const placeholder = element("div", "resolver-contestant__visual-placeholder");
         placeholder.append(
@@ -391,34 +475,48 @@ export class ResolverPage {
     }
     const names = element("div", "resolver-contestant__names");
     const handle = contestant.profileUrl
-      ? element("a", "resolver-contestant__handle", contestant.username)
-      : element("strong", "resolver-contestant__handle", contestant.username);
+      ? element("a", "resolver-contestant__handle", contestant.displayName || contestant.username)
+      : element(
+          "strong",
+          "resolver-contestant__handle",
+          contestant.displayName || contestant.username,
+        );
     if (contestant.profileUrl) {
       handle.href = contestant.profileUrl;
     }
     const rating = element("span", contestant.cssClass || "rating rate-none user");
     rating.append(handle);
     names.append(rating);
-    if (contestant.displayName && contestant.displayName !== contestant.username) {
+    if (contestant.fullName) {
       names.append(
-        element("div", "personal-info resolver-contestant__display", contestant.displayName),
+        element("div", "personal-info resolver-contestant__display", contestant.fullName),
       );
     }
-    const organization = contestant.organization?.short_name || contestant.organization?.name;
     identity.append(names);
     const side = element("div", "resolver-contestant__side");
-    const revealContestant = element("button", "resolver-row-reveal");
-    revealContestant.type = "button";
-    revealContestant.dataset.resolverAction = "reveal-contestant";
-    revealContestant.dataset.contestantId = contestant.participationId;
-    revealContestant.setAttribute("aria-label", `Reveal ${contestant.username}`);
-    revealContestant.title = "Reveal contestant";
-    revealContestant.append(element("i", "fa fa-play fa-fw"));
-    revealContestant.disabled =
-      this.busy || !this._resolvableForContestant(contestant.participationId).length;
-    side.append(revealContestant);
-    if (organization) {
-      side.append(element("div", "personal-info resolver-contestant__organization", organization));
+    const organizations = getOrganizationPresentation(contestant.organizations);
+    if (organizations.length) {
+      const organizationList = element("div", "personal-info resolver-contestant__organization");
+      organizations.forEach((organization, index) => {
+        if (index) {
+          organizationList.append(document.createTextNode(" | "));
+        }
+        const name = organization.label;
+        if (organization.url) {
+          const link = element("a", "", name);
+          link.href = organization.url;
+          organizationList.append(link);
+        } else {
+          organizationList.append(element("span", "", name));
+        }
+      });
+      side.append(organizationList);
+    }
+    if (this._resolvableForContestant(contestant.participationId).length) {
+      contestantCell.dataset.resolverAction = "reveal-contestant";
+      contestantCell.dataset.contestantId = contestant.participationId;
+      contestantCell.tabIndex = 0;
+      contestantCell.title = `Reveal ${contestant.username}`;
     }
     layout.append(identity, side);
     contestantCell.append(layout);
@@ -459,6 +557,15 @@ export class ResolverPage {
       if (sourceStateClass) {
         tableCell.classList.add(sourceStateClass);
       }
+      if (view.state === "pending") {
+        if (cell.points === problem.max_score) {
+          tableCell.classList.add("full-score");
+        } else if (cell.points !== 0) {
+          tableCell.classList.add("partial-score");
+        } else {
+          tableCell.classList.add("failed-score");
+        }
+      }
       tableCell.dataset.problemId = problem.id;
       tableCell.dataset.label = problem.label;
       const stat = statsByProblem.get(problemId);
@@ -470,9 +577,9 @@ export class ResolverPage {
         tableCell.classList.add("resolver-cell--first-solve", "first-solve");
       }
       if (
-        nextTarget &&
-        normalizedId(nextTarget.contestantId) === normalizedId(contestant.participationId) &&
-        normalizedId(nextTarget.problemId) === problemId
+        activeSelection?.problemId &&
+        normalizedId(activeSelection.contestantId) === normalizedId(contestant.participationId) &&
+        normalizedId(activeSelection.problemId) === problemId
       ) {
         tableCell.classList.add("resolver-cell--target");
       }
@@ -493,9 +600,30 @@ export class ResolverPage {
       } else {
         content.setAttribute("aria-label", view.accessibleLabel);
       }
-      content.append(element("span", "resolver-cell__primary", view.primary));
+      const primaryClass =
+        this.payload.contest.format === "icpc" && view.state === "solved"
+          ? "resolver-cell__primary solving-time-minute"
+          : "resolver-cell__primary";
+      content.append(element("span", primaryClass, view.primary));
+      if (view.penalty) {
+        content.append(element("small", "resolver-cell__penalty", ` (${view.penalty})`));
+      }
+      if (view.pendingCount) {
+        content.append(element("small", "resolver-cell__pending-count", ` [${view.pendingCount}]`));
+      }
+      if (this.payload.contest.format === "icpc" && view.state === "solved" && view.time) {
+        content.append(element("span", "solving-time", view.time));
+      }
       if (view.secondary) {
-        content.append(element("span", "resolver-cell__secondary", view.secondary));
+        content.append(
+          element(
+            "span",
+            this.payload.contest.format === "icpc"
+              ? "resolver-cell__secondary resolver-cell__tries"
+              : "resolver-cell__secondary solving-time",
+            view.secondary,
+          ),
+        );
       }
       tableCell.append(content);
       row.append(tableCell);
@@ -505,7 +633,11 @@ export class ResolverPage {
 
   _renderTotals(stats) {
     const row = element("tr", "resolver-total-row");
-    const label = element("td", "resolver-total-label", "Total AC");
+    const label = element(
+      "td",
+      "resolver-total-label",
+      this.root.dataset.labelTotalAc || "Total AC",
+    );
     label.colSpan = this.payload.contest.format === "icpc" ? 4 : 3;
     row.append(label);
     stats.forEach((stat) => {
@@ -513,69 +645,123 @@ export class ResolverPage {
       total.dataset.problemId = stat.problemId;
       row.append(total);
     });
-    this.nodes.tableFoot.replaceChildren(row);
+    return row;
   }
 
-  _renderControls(nextTarget) {
+  _currentProjection() {
+    if (!this.planner || this.policyName === "manual") {
+      return null;
+    }
+    const playerState = this.player?.getState();
+    if (playerState?.presentation.selectedContestantId && playerState.projection) {
+      return playerState.projection;
+    }
+    return this.planner.projectNext(this.session);
+  }
+
+  _renderControls() {
     if (!this.session) {
       return;
     }
     const history = this.session.getHistory();
     const remaining = this.session.getResolvableCells().length;
     const revealed = this.totalResolvable - remaining;
-    const autoplay = this.autoplay.getState();
+    const nextTarget = this._selectTarget();
+    const playerState = this.player?.getState() ?? {
+      running: false,
+      checkpointIndex: 0,
+      checkpointCount: 1,
+      presentation: {},
+    };
+    const speed = SPEED_PRESETS[this.speedIndex];
     this.nodes.progress.textContent = `${revealed} / ${this.totalResolvable} cells resolved`;
     this.nodes.status.textContent = remaining
       ? this.statusMessage
       : "Resolver complete — final standings reached.";
-    this.nodes.play.innerHTML = autoplay.playing
+    this.nodes.play.innerHTML = playerState.running
       ? '<i class="fa fa-pause"></i> Pause'
       : '<i class="fa fa-play"></i> Play';
-    this.nodes.play.disabled = this.policyName === "manual" || (!nextTarget && !autoplay.playing);
-    this.nodes.play.setAttribute("aria-pressed", String(autoplay.playing));
-    this.nodes.speedLabel.textContent = autoplay.speed.label;
-    this.nodes.slower.disabled = autoplay.speedIndex === 0;
-    this.nodes.faster.disabled = autoplay.speedIndex === 3;
-    this.nodes.back.disabled = this.busy || history.cursor === 0;
-    this.nodes.forward.disabled = this.busy || history.cursor >= history.transitions.length;
-    this.nodes.reset.disabled = this.busy || history.cursor === 0;
+    this.nodes.play.disabled =
+      this.policyName === "manual" ||
+      (!nextTarget && !playerState.projection && !playerState.running);
+    this.nodes.play.setAttribute("aria-pressed", String(playerState.running));
+    this.nodes.speedLabel.textContent = speed.label;
+    this.nodes.slower.disabled = this.speedIndex === 0;
+    this.nodes.faster.disabled = this.speedIndex === SPEED_PRESETS.length - 1;
+    this.nodes.back.disabled =
+      this.busy ||
+      playerState.running ||
+      (this.policyName === "manual" ? history.cursor === 0 : playerState.checkpointIndex === 0);
+    this.nodes.forward.disabled =
+      this.busy ||
+      playerState.running ||
+      (this.policyName === "manual"
+        ? history.cursor >= history.transitions.length
+        : !nextTarget && !playerState.projection);
+    this.nodes.reset.disabled =
+      this.busy ||
+      (this.policyName === "manual"
+        ? history.cursor === 0
+        : playerState.checkpointIndex === 0 && history.cursor === 0);
     this.nodes.replay.disabled = this.busy || this.totalResolvable === 0;
     this.nodes.changeSetup.disabled = this.busy;
     this.nodes.next.disabled =
-      this.busy || autoplay.playing || this.policyName === "manual" || !nextTarget;
-    this.nodes.next.textContent =
-      this.granularity === "contestant" ? "Reveal next contestant" : "Reveal next cell";
+      this.busy ||
+      playerState.running ||
+      this.policyName === "manual" ||
+      (!nextTarget && !playerState.projection);
+    this.nodes.next.textContent = "Forward";
+    this.nodes.forward.textContent = this.policyName === "manual" ? "Forward" : "Fast forward";
     this.nodes.toggleHud.setAttribute("aria-pressed", String(this.hudVisible));
     this.nodes.hud.hidden = !this.hudVisible;
     this.nodes.fullscreen.innerHTML = document.fullscreenElement
       ? '<i class="fa fa-compress"></i> Exit fullscreen'
       : '<i class="fa fa-expand"></i> Fullscreen';
-    this._renderHud(nextTarget, history, autoplay);
+    this._renderHud(this._currentProjection(), history, playerState, speed);
   }
 
-  _renderHud(nextTarget, history, autoplay) {
+  _renderHud(projection, history, playerState, speed) {
     const baseline = this.session.baseline === "official-freeze" ? "Freeze" : "Beginning";
-    const playback = autoplay.playing
-      ? `playing ${autoplay.speed.label}`
-      : `paused ${autoplay.speed.label}`;
+    const playback = playerState.running ? `playing ${speed.label}` : `paused ${speed.label}`;
     this.nodes.hudMode.textContent = `${baseline} · ${
       POLICY_LABELS[this.policyName]
     } · ${playback}`;
-    if (nextTarget) {
+    if (projection) {
       const contestant = this.payload.contestants.find(
-        (entry) => normalizedId(entry.participation_id) === normalizedId(nextTarget.contestantId),
+        (entry) =>
+          normalizedId(entry.participation_id) === normalizedId(projection.target.contestantId),
       );
       const problem = this.problems.find(
-        (entry) => normalizedId(entry.id) === normalizedId(nextTarget.problemId),
+        (entry) => normalizedId(entry.id) === normalizedId(projection.target.problemId),
       );
-      this.nodes.hudTarget.textContent = `${contestant?.username ?? nextTarget.contestantId} / ${
-        problem?.label ?? nextTarget.problemId
-      }`;
+      this.nodes.hudTarget.textContent = `${
+        contestant?.display_name || contestant?.username || projection.target.contestantId
+      } / ${problem?.label ?? projection.target.problemId}`;
+      this.nodes.hudCurrentPosition.textContent = `#${projection.currentPosition} (rank ${projection.currentRank})`;
+      this.nodes.hudAfterPosition.textContent = `#${projection.actualPositionAfterReveal} (rank ${projection.actualRankAfterReveal})`;
+      this.nodes.hudMovement.textContent = projection.movementDelta
+        ? `↑ ${projection.movementDelta}`
+        : "—";
+      this.nodes.hudZone.textContent = projection.entersSingleStepZone
+        ? `Enters top ${this.singleStepStartRank}`
+        : projection.isSingleStep
+        ? `Top ${this.singleStepStartRank}`
+        : "Scoreboard timing";
+      this.nodes.hudRemaining.textContent = String(projection.remainingUnresolvedCells);
     } else {
       this.nodes.hudTarget.textContent = "—";
+      this.nodes.hudCurrentPosition.textContent = "—";
+      this.nodes.hudAfterPosition.textContent = "—";
+      this.nodes.hudMovement.textContent = "—";
+      this.nodes.hudZone.textContent = "—";
+      this.nodes.hudRemaining.textContent = String(this.session.getResolvableCells().length);
     }
-    this.nodes.hudHistory.textContent = `${history.cursor} / ${history.transitions.length}`;
-    this.nodes.hudAward.textContent = this.awardPlaces ? `Top ${this.awardPlaces}` : "Off";
+    this.nodes.hudHistory.textContent = `${history.cursor} / ${
+      history.transitions.length
+    } · pause ${playerState.checkpointIndex} / ${Math.max(0, playerState.checkpointCount - 1)}`;
+    this.nodes.hudAward.textContent = this.awardPlaces
+      ? `Top ${this.awardPlaces} timing boundary`
+      : "Off";
     this.nodes.hudSeed.textContent = this.session.seed;
   }
 
@@ -589,23 +775,98 @@ export class ResolverPage {
       .filter((cell) => normalizedId(cell.contestantId) === normalizedId(contestantId));
   }
 
-  async _stepFromOperator(label) {
-    this._pauseAutoplay();
-    await this._revealNext(label);
+  _beforePlayerStep(step) {
+    if (step.type !== RESOLUTION_STEP_TYPES.REVEAL_CELL) {
+      return null;
+    }
+    this.busy = true;
+    return captureRowPositions(this.nodes.tableBody);
   }
 
-  async _revealNext(label = "Reveal") {
-    if (this.busy || this.policyName === "manual") {
-      return null;
+  async _performPlayerStep(step, context) {
+    if (step.type === RESOLUTION_STEP_TYPES.SCROLL_ROW) {
+      const row = [...this.nodes.tableBody.querySelectorAll("tr[data-contestant-id]")].find(
+        (candidate) =>
+          normalizedId(candidate.dataset.contestantId) === normalizedId(step.target.contestantId),
+      );
+      row?.scrollIntoView({ block: "center", behavior: "smooth" });
+      return;
     }
-    const target = this.policy.select(this.session);
-    if (!target) {
-      return null;
+
+    if (step.type === RESOLUTION_STEP_TYPES.SELECT_TEAM) {
+      this.statusMessage = `Selected ${step.contestantLabel}.`;
+    } else if (step.type === RESOLUTION_STEP_TYPES.SELECT_PROBLEM) {
+      this.statusMessage = `Selected problem ${step.problemLabel}.`;
+    } else if (step.type === RESOLUTION_STEP_TYPES.REVEAL_CELL) {
+      const transition = context.transition;
+      this.statusMessage = `Revealed ${step.contestantLabel}, problem ${step.problemLabel}.`;
+      this._render();
+      await Promise.all([
+        animateRows(this.nodes.tableBody, context.beforeContext, 700),
+        animateChangedCells(this.nodes.tableBody, [transition.target]),
+      ]);
+      this.busy = false;
+    } else if (step.type === RESOLUTION_STEP_TYPES.RESULT_MOVE) {
+      this.statusMessage = `${step.contestantLabel} moved up ${step.movementDelta} position${
+        step.movementDelta === 1 ? "" : "s"
+      }.`;
+    } else if (step.type === RESOLUTION_STEP_TYPES.RESULT_STAY) {
+      this.statusMessage = `${step.contestantLabel} stays in the same position.`;
+    } else if (step.type === RESOLUTION_STEP_TYPES.RESULT_FAILED) {
+      this.statusMessage = `${step.contestantLabel} received no meaningful score improvement.`;
+    } else if (step.type === RESOLUTION_STEP_TYPES.PAUSE) {
+      this.statusMessage = `${step.reason} Press Space or Forward to continue.`;
     }
-    if (this.granularity === "contestant") {
-      return this._revealContestant(target.contestantId, `${label}, contestant`);
+    this._render();
+  }
+
+  async _restorePlayerView() {
+    this.busy = false;
+    this.statusMessage = this.player?.getState().pauseReason ?? "Resolver state restored.";
+    this._render();
+  }
+
+  _onPlayerChange(state) {
+    if (!this.session) {
+      return;
     }
-    return this._revealTargets([target], `${label}, cell`);
+    if (state.running) {
+      this.statusMessage = `Playing at ${SPEED_PRESETS[this.speedIndex].label}.`;
+    } else if (state.pauseReason) {
+      this.statusMessage = state.pauseReason;
+    }
+    this._render();
+  }
+
+  _playToNextPause(includeDelays) {
+    if (this.busy || !this.player || this.policyName === "manual") {
+      return Promise.resolve(null);
+    }
+    return this.player.playToNextPause(includeDelays);
+  }
+
+  _togglePlayback() {
+    if (!this.player || this.policyName === "manual") {
+      return;
+    }
+    if (this.player.getState().running) {
+      this.player.cancel();
+    } else if (!this.busy) {
+      void this.player.playToNextPause(true);
+    }
+  }
+
+  _pausePlayback(reason = "Playback paused.") {
+    if (this.player?.getState().running) {
+      this.player.cancel(reason, "operator");
+    }
+  }
+
+  _changeSpeed(delta) {
+    this.speedIndex = clampSpeedIndex(this.speedIndex + delta);
+    this.nodes.speed.value = String(this.speedIndex);
+    this.player?.setSpeed(SPEED_PRESETS[this.speedIndex].speed);
+    this._renderControls();
   }
 
   async _revealContestant(contestantId, label) {
@@ -638,58 +899,11 @@ export class ResolverPage {
       ),
     ]);
     this.busy = false;
+    if (this.player) {
+      await this.player.syncAfterExternalChange(label);
+    }
     this._render();
     return { transitions };
-  }
-
-  async _autoplayStep() {
-    const result = await this._revealNext("Autoplay");
-    if (!result) {
-      return { complete: true, pauseReason: null };
-    }
-    const complete = this.session.getResolvableCells().length === 0;
-    return {
-      complete,
-      pauseReason: complete
-        ? null
-        : getPauseReason(result.transitions, this.pauseBeats, this.awardPlaces),
-    };
-  }
-
-  _toggleAutoplay() {
-    if (this.policyName === "manual") {
-      return;
-    }
-    if (this.autoplay.playing) {
-      this.autoplay.pause();
-      return;
-    }
-    if (this.busy) {
-      return;
-    }
-    this.autoplay.toggle();
-  }
-
-  _pauseAutoplay(reason = "Autoplay paused.") {
-    if (this.autoplay.playing) {
-      this.autoplay.pause(reason, "operator");
-    }
-  }
-
-  _onAutoplayChange(state) {
-    if (!this.session) {
-      return;
-    }
-    if (state.playing) {
-      this.statusMessage = `Autoplay running at ${state.speed.label}.`;
-    } else if (state.pauseKind === "beat") {
-      this.statusMessage = `Paused on ceremony beat — ${state.pauseReason} Press Space to resume.`;
-    } else if (state.pauseKind === "complete") {
-      this.statusMessage = state.pauseReason;
-    } else if (state.pauseReason) {
-      this.statusMessage = state.pauseReason;
-    }
-    this._render();
   }
 
   async _moveHistory(direction) {
@@ -727,7 +941,9 @@ export class ResolverPage {
     }
     this.busy = true;
     const previousPositions = captureRowPositions(this.nodes.tableBody);
-    if (useReplay) {
+    if (this.player && this.policyName !== "manual") {
+      await this.player.resetToBeginning();
+    } else if (useReplay) {
       this.session.replay();
     } else {
       this.session.reset();
@@ -741,16 +957,16 @@ export class ResolverPage {
   }
 
   async _replay() {
-    this._pauseAutoplay();
+    this._pausePlayback();
     await this._reset(true);
-    if (this.policyName !== "manual" && this.session.getResolvableCells().length) {
-      this.autoplay.play();
+    if (this.player && this.session.getResolvableCells().length) {
+      void this.player.playToNextPause(true);
     }
   }
 
   _toggleHud() {
     this.hudVisible = !this.hudVisible;
-    this._renderControls(this._selectTarget());
+    this._renderControls();
   }
 
   _showShortcuts() {
@@ -807,25 +1023,26 @@ export class ResolverPage {
     }
     if (key === "p") {
       event.preventDefault();
-      this._toggleAutoplay();
+      this._togglePlayback();
     } else if (key === " ") {
       event.preventDefault();
-      if (this.autoplay.playing) {
-        this.autoplay.pause();
-      } else if (this.autoplay.pauseKind === "beat") {
-        this.autoplay.play();
+      if (this.player?.getState().running) {
+        this.player.cancel();
       } else {
-        void this._stepFromOperator("Keyboard step");
+        void this._playToNextPause(true);
       }
     } else if (key === "[") {
       event.preventDefault();
-      this.autoplay.slower();
+      this._changeSpeed(-1);
     } else if (key === "]") {
       event.preventDefault();
-      this.autoplay.faster();
+      this._changeSpeed(1);
     } else if (/^[1-4]$/.test(key)) {
       event.preventDefault();
-      this.autoplay.setSpeed(Number(key) - 1);
+      this.speedIndex = Number(key) - 1;
+      this.nodes.speed.value = String(this.speedIndex);
+      this.player?.setSpeed(SPEED_PRESETS[this.speedIndex].speed);
+      this._renderControls();
     } else if (key === "h") {
       event.preventDefault();
       this._toggleHud();
@@ -834,17 +1051,22 @@ export class ResolverPage {
       void this._toggleFullscreen();
     } else if (key === "backspace" || key === "arrowleft") {
       event.preventDefault();
-      this._pauseAutoplay();
-      void this._moveHistory("back");
+      this._pausePlayback();
+      if (this.policyName === "manual") {
+        void this._moveHistory("back");
+      } else {
+        void this.player?.rewindToPreviousPause();
+      }
     } else if (key === "arrowright") {
       event.preventDefault();
-      this._pauseAutoplay();
-      const history = this.session.getHistory();
-      if (history.cursor < history.transitions.length) {
+      if (this.policyName === "manual") {
         void this._moveHistory("forward");
       } else {
-        void this._revealNext("Keyboard next");
+        void this._playToNextPause(true);
       }
+    } else if (key === ".") {
+      event.preventDefault();
+      void this._playToNextPause(false);
     }
   }
 }

--- a/resources/resolver/page.js
+++ b/resources/resolver/page.js
@@ -1,0 +1,850 @@
+import { animateChangedCells, animateRows, captureRowPositions } from "./animation.js";
+import {
+  AutoplayController,
+  CEREMONY_PRESETS,
+  getPauseReason,
+  normalizeAwardPlaces,
+} from "./controller.js";
+import { ResolverSession } from "./core.js";
+import { BottomUpStickyPolicy, ByContestantPolicy, ByProblemPolicy } from "./policies.js";
+import { deriveProblemStats, getCellPresentation, getMetricPresentation } from "./presentation.js";
+
+function element(tagName, className = "", text = null) {
+  const node = document.createElement(tagName);
+  if (className) {
+    node.className = className;
+  }
+  if (text !== null) {
+    node.textContent = text;
+  }
+  return node;
+}
+
+function normalizedId(value) {
+  return String(value);
+}
+
+function isTypingTarget(target) {
+  return (
+    target instanceof HTMLElement &&
+    (target.matches("input, textarea, select") || target.isContentEditable)
+  );
+}
+
+const POLICY_LABELS = Object.freeze({
+  "bottom-up-sticky": "Bottom-up",
+  "by-problem": "By problem",
+  "by-contestant": "By contestant",
+  manual: "Manual",
+});
+
+export class ResolverPage {
+  constructor(root, payload) {
+    this.root = root;
+    this.payload = payload;
+    this.problems = [...payload.problems].sort(
+      (left, right) => left.order - right.order || String(left.id).localeCompare(String(right.id)),
+    );
+    this.session = null;
+    this.policy = new BottomUpStickyPolicy();
+    this.policyName = "bottom-up-sticky";
+    this.granularity = "cell";
+    this.pauseBeats = { ...CEREMONY_PRESETS.icpc.pauseBeats };
+    this.awardPlaces = Math.min(3, payload.contestants.length);
+    this.busy = false;
+    this.totalResolvable = 0;
+    this.hudVisible = true;
+    this.activePreset = "icpc";
+    this.statusMessage = "Choose a ceremony preset to begin.";
+    this.helpReturnFocus = null;
+
+    this.nodes = {
+      setup: root.querySelector("#resolver-setup"),
+      setupForm: root.querySelector("#resolver-setup-form"),
+      presetButtons: [...root.querySelectorAll("[data-resolver-preset]")],
+      baseline: root.querySelector("#resolver-baseline"),
+      policy: root.querySelector("#resolver-policy"),
+      granularity: root.querySelector("#resolver-granularity"),
+      tieOrder: root.querySelector("#resolver-tie-order"),
+      speed: root.querySelector("#resolver-speed"),
+      awardPlaces: root.querySelector("#resolver-award-places"),
+      pauseRank: root.querySelector('[name="pause_rank"]'),
+      pauseAward: root.querySelector('[name="pause_award"]'),
+      pauseFinished: root.querySelector('[name="pause_finished"]'),
+      pauseFirstSolve: root.querySelector('[name="pause_first_solve"]'),
+      freezeNote: root.querySelector("#resolver-freeze-note"),
+      workspace: root.querySelector("#resolver-workspace"),
+      table: root.querySelector("#ranking-table"),
+      tableHead: root.querySelector("#resolver-table-head"),
+      tableBody: root.querySelector("#resolver-table-body"),
+      tableFoot: root.querySelector("#resolver-table-foot"),
+      status: root.querySelector("#resolver-status"),
+      progress: root.querySelector("#resolver-progress"),
+      next: root.querySelector("#resolver-next"),
+      play: root.querySelector("#resolver-play"),
+      slower: root.querySelector("#resolver-slower"),
+      faster: root.querySelector("#resolver-faster"),
+      speedLabel: root.querySelector("#resolver-speed-label"),
+      back: root.querySelector("#resolver-back"),
+      forward: root.querySelector("#resolver-forward"),
+      reset: root.querySelector("#resolver-reset"),
+      replay: root.querySelector("#resolver-replay"),
+      toggleHud: root.querySelector("#resolver-toggle-hud"),
+      help: root.querySelector("#resolver-help"),
+      fullscreen: root.querySelector("#resolver-fullscreen"),
+      changeSetup: root.querySelector("#resolver-change-setup"),
+      hud: root.querySelector("#resolver-hud"),
+      hudMode: root.querySelector("#resolver-hud-mode"),
+      hudTarget: root.querySelector("#resolver-hud-target"),
+      hudHistory: root.querySelector("#resolver-hud-history"),
+      hudAward: root.querySelector("#resolver-hud-award"),
+      hudSeed: root.querySelector("#resolver-hud-seed"),
+      shortcuts: root.querySelector("#resolver-shortcuts"),
+      shortcutsClose: root.querySelector("#resolver-shortcuts-close"),
+    };
+    this.autoplay = new AutoplayController({
+      step: () => this._autoplayStep(),
+      onChange: (state) => this._onAutoplayChange(state),
+      speedIndex: 1,
+    });
+  }
+
+  mount() {
+    this._configureSetup();
+    this._applyPreset("icpc");
+    this._bindEvents();
+    this.nodes.setup.hidden = false;
+    this.nodes.workspace.hidden = true;
+  }
+
+  _configureSetup() {
+    const freezeAvailable = this.payload.contest.official_freeze_available;
+    const autoOption = this.nodes.baseline.querySelector('option[value="auto"]');
+    const freezeOption = this.nodes.baseline.querySelector('option[value="official-freeze"]');
+    autoOption.textContent = freezeAvailable ? "Auto (official freeze)" : "Auto (beginning)";
+    freezeOption.disabled = !freezeAvailable;
+    this.nodes.awardPlaces.max = String(this.payload.contestants.length);
+    this.nodes.awardPlaces.value = String(this.awardPlaces);
+    this.nodes.freezeNote.textContent = freezeAvailable
+      ? `Official freeze is available (${this.payload.contest.frozen_last_minutes} minutes).`
+      : "This format has no native official-freeze state; Auto uses Beginning.";
+  }
+
+  _bindEvents() {
+    this.nodes.setupForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      this._start();
+    });
+    this.nodes.presetButtons.forEach((button) => {
+      button.addEventListener("click", () => this._applyPreset(button.dataset.resolverPreset));
+    });
+    this.nodes.setupForm.addEventListener("change", (event) => {
+      if (!event.target.closest("[data-resolver-preset]")) {
+        this.activePreset = "custom";
+        this._renderPresetSelection();
+      }
+    });
+    this.nodes.next.addEventListener("click", () => this._stepFromOperator("Next control"));
+    this.nodes.play.addEventListener("click", () => this._toggleAutoplay());
+    this.nodes.slower.addEventListener("click", () => this.autoplay.slower());
+    this.nodes.faster.addEventListener("click", () => this.autoplay.faster());
+    this.nodes.back.addEventListener("click", () => {
+      this._pauseAutoplay();
+      void this._moveHistory("back");
+    });
+    this.nodes.forward.addEventListener("click", () => {
+      this._pauseAutoplay();
+      void this._moveHistory("forward");
+    });
+    this.nodes.reset.addEventListener("click", () => {
+      this._pauseAutoplay();
+      void this._reset(false);
+    });
+    this.nodes.replay.addEventListener("click", () => void this._replay());
+    this.nodes.toggleHud.addEventListener("click", () => this._toggleHud());
+    this.nodes.help.addEventListener("click", () => this._showShortcuts());
+    this.nodes.shortcutsClose.addEventListener("click", () => this._hideShortcuts());
+    this.nodes.shortcuts.addEventListener("click", (event) => {
+      if (event.target === this.nodes.shortcuts) {
+        this._hideShortcuts();
+      }
+    });
+    this.nodes.fullscreen.addEventListener("click", () => void this._toggleFullscreen());
+    this.nodes.changeSetup.addEventListener("click", () => this._showSetup());
+    this.nodes.tableBody.addEventListener("click", (event) => {
+      const button = event.target.closest("button[data-resolver-action]");
+      if (!button || this.busy) {
+        return;
+      }
+      this._pauseAutoplay("Autoplay paused for a manual reveal.");
+      this.policy.clear();
+      if (button.dataset.resolverAction === "reveal-cell") {
+        void this._revealTargets(
+          [
+            {
+              contestantId: button.dataset.contestantId,
+              problemId: button.dataset.problemId,
+            },
+          ],
+          "Manual cell reveal",
+        );
+      } else if (button.dataset.resolverAction === "reveal-contestant") {
+        void this._revealContestant(button.dataset.contestantId, "Manual contestant reveal");
+      }
+    });
+    document.addEventListener("keydown", (event) => this._handleShortcut(event));
+    document.addEventListener("fullscreenchange", () => this._renderControls(this._selectTarget()));
+  }
+
+  _applyPreset(name) {
+    const preset = CEREMONY_PRESETS[name];
+    if (!preset) {
+      return;
+    }
+    this.activePreset = name;
+    this.nodes.baseline.value = preset.baseline;
+    this.nodes.policy.value = preset.policy;
+    this.nodes.granularity.value = preset.granularity;
+    this.nodes.tieOrder.value = preset.tieOrder;
+    this.nodes.speed.value = String(preset.speedIndex);
+    this.nodes.pauseRank.checked = preset.pauseBeats.rankChange;
+    this.nodes.pauseAward.checked = preset.pauseBeats.awardZone;
+    this.nodes.pauseFinished.checked = preset.pauseBeats.contestantFinished;
+    this.nodes.pauseFirstSolve.checked = preset.pauseBeats.firstSolve;
+    this.autoplay.setSpeed(preset.speedIndex);
+    this._renderPresetSelection();
+  }
+
+  _renderPresetSelection() {
+    this.nodes.presetButtons.forEach((button) => {
+      button.setAttribute(
+        "aria-pressed",
+        String(button.dataset.resolverPreset === this.activePreset),
+      );
+    });
+  }
+
+  _start() {
+    this._pauseAutoplay();
+    try {
+      this.session = new ResolverSession(this.payload, {
+        baseline: this.nodes.baseline.value,
+        tieOrder: this.nodes.tieOrder.value,
+      });
+    } catch (error) {
+      this.nodes.freezeNote.textContent = `Resolver could not start: ${error.message}`;
+      return;
+    }
+
+    this.policyName = this.nodes.policy.value;
+    this.granularity = this.nodes.granularity.value;
+    this.policy = this._createPolicy(this.policyName);
+    this.awardPlaces = normalizeAwardPlaces(
+      this.nodes.awardPlaces.value,
+      this.payload.contestants.length,
+    );
+    this.nodes.awardPlaces.value = String(this.awardPlaces);
+    this.pauseBeats = {
+      rankChange: this.nodes.pauseRank.checked,
+      awardZone: this.nodes.pauseAward.checked,
+      contestantFinished: this.nodes.pauseFinished.checked,
+      firstSolve: this.nodes.pauseFirstSolve.checked,
+    };
+    this.autoplay.setSpeed(Number(this.nodes.speed.value));
+    this.totalResolvable = this.session.getResolvableCells().length;
+    this.statusMessage = `Started from ${this._baselineLabel()}.`;
+    this.nodes.setup.hidden = true;
+    this.nodes.workspace.hidden = false;
+    window.CHTOJResolverSession = this.session;
+    this._renderTableHead();
+    this._render();
+  }
+
+  _createPolicy(name) {
+    if (name === "by-problem") {
+      return new ByProblemPolicy(this.problems.map((problem) => problem.id));
+    }
+    if (name === "by-contestant") {
+      return new ByContestantPolicy();
+    }
+    return new BottomUpStickyPolicy();
+  }
+
+  _showSetup() {
+    if (this.busy) {
+      return;
+    }
+    this._pauseAutoplay();
+    this.nodes.workspace.hidden = true;
+    this.nodes.setup.hidden = false;
+    this.nodes.baseline.focus();
+  }
+
+  _baselineLabel() {
+    return this.session.baseline === "official-freeze" ? "official freeze" : "the beginning";
+  }
+
+  _renderTableHead() {
+    const formatName = this.payload.contest.format;
+    const metrics = getMetricPresentation(formatName, { score: 0, cumtime: 0 });
+    const labels = this.root.dataset;
+    const row = element("tr");
+    const coreHeaders = [
+      { label: labels.labelRank || "Rank", className: "header rank" },
+      { label: labels.labelUsername || "Username", className: "header username" },
+      { label: labels.labelScore || metrics.scoreLabel, className: "header points" },
+    ];
+    if (formatName === "icpc") {
+      coreHeaders.push({
+        label: labels.labelPenalty || metrics.timeLabel,
+        className: "header penalty",
+      });
+    }
+    coreHeaders.forEach(({ label, className }) => {
+      const header = element("th", `resolver-heading ${className}`, label);
+      header.scope = "col";
+      row.append(header);
+    });
+    this.problems.forEach((problem) => {
+      const header = element("th", "resolver-heading resolver-heading--problem header points");
+      header.scope = "col";
+      header.title = `${problem.code} — ${problem.name}`;
+      header.append(element("span", "resolver-problem-label", problem.label));
+      if (formatName !== "icpc") {
+        header.append(
+          element(
+            "span",
+            "resolver-problem-denominator point-denominator",
+            String(problem.max_score),
+          ),
+        );
+      }
+      row.append(header);
+    });
+    this.nodes.tableHead.replaceChildren(row);
+  }
+
+  _render() {
+    if (!this.session) {
+      return;
+    }
+    const state = this.session.getState();
+    const contestants = new Map(
+      state.contestants.map((contestant) => [normalizedId(contestant.participationId), contestant]),
+    );
+    const stats = deriveProblemStats(this.payload, state);
+    const statsByProblem = new Map(stats.map((stat) => [normalizedId(stat.problemId), stat]));
+    const nextTarget = this._selectTarget();
+    const rows = state.standings.map((standing) => {
+      const contestant = contestants.get(normalizedId(standing.contestantId));
+      return this._renderContestantRow(contestant, standing, statsByProblem, nextTarget);
+    });
+    this.nodes.tableBody.replaceChildren(...rows);
+    this._renderTotals(stats);
+    this._renderControls(nextTarget);
+  }
+
+  _renderContestantRow(contestant, standing, statsByProblem, nextTarget) {
+    const row = element("tr", "resolver-row");
+    row.dataset.contestantId = contestant.participationId;
+    if (contestant.isDisqualified) {
+      row.classList.add("resolver-row--disqualified", "disqualified");
+    } else if (this.awardPlaces > 0 && standing.rank <= this.awardPlaces) {
+      row.classList.add("resolver-row--award");
+      if (standing.rank === 1) {
+        row.classList.add("resolver-row--award-first");
+      }
+    }
+    if (
+      nextTarget &&
+      normalizedId(nextTarget.contestantId) === normalizedId(contestant.participationId)
+    ) {
+      row.classList.add("resolver-row--target");
+    }
+
+    const rank = element("td", "resolver-rank ranking-column");
+    rank.append(element("div", "", String(standing.rank)));
+    rank.dataset.label = "Rank";
+    const contestantCell = element("td", "user-name resolver-contestant");
+    contestantCell.dataset.label = "Contestant";
+    const layout = element("div", "resolver-contestant__layout");
+    const identity = element("div", "usr-ranking-left resolver-contestant__identity");
+    const rankDisplayOptions = Number(this.payload.contest.rank_display_options ?? 1);
+    if (rankDisplayOptions !== 3) {
+      const visual = element("div", "u-logo-ranking");
+      const visualUrl = rankDisplayOptions === 2 ? contestant.rankLogoUrl : contestant.avatarUrl;
+      if (visualUrl) {
+        const avatar = element("img", "resolver-contestant__avatar");
+        avatar.src = visualUrl;
+        avatar.alt = "";
+        avatar.width = 64;
+        avatar.height = 64;
+        visual.append(avatar);
+      } else {
+        const placeholder = element("div", "resolver-contestant__visual-placeholder");
+        placeholder.append(
+          element("i", `fa ${rankDisplayOptions === 2 ? "fa-graduation-cap" : "fa-user"}`),
+        );
+        visual.append(placeholder);
+      }
+      identity.append(visual, element("div", "u-logo-sep1"));
+    }
+    const names = element("div", "resolver-contestant__names");
+    const handle = contestant.profileUrl
+      ? element("a", "resolver-contestant__handle", contestant.username)
+      : element("strong", "resolver-contestant__handle", contestant.username);
+    if (contestant.profileUrl) {
+      handle.href = contestant.profileUrl;
+    }
+    const rating = element("span", contestant.cssClass || "rating rate-none user");
+    rating.append(handle);
+    names.append(rating);
+    if (contestant.displayName && contestant.displayName !== contestant.username) {
+      names.append(
+        element("div", "personal-info resolver-contestant__display", contestant.displayName),
+      );
+    }
+    const organization = contestant.organization?.short_name || contestant.organization?.name;
+    identity.append(names);
+    const side = element("div", "resolver-contestant__side");
+    const revealContestant = element("button", "resolver-row-reveal");
+    revealContestant.type = "button";
+    revealContestant.dataset.resolverAction = "reveal-contestant";
+    revealContestant.dataset.contestantId = contestant.participationId;
+    revealContestant.setAttribute("aria-label", `Reveal ${contestant.username}`);
+    revealContestant.title = "Reveal contestant";
+    revealContestant.append(element("i", "fa fa-play fa-fw"));
+    revealContestant.disabled =
+      this.busy || !this._resolvableForContestant(contestant.participationId).length;
+    side.append(revealContestant);
+    if (organization) {
+      side.append(element("div", "personal-info resolver-contestant__organization", organization));
+    }
+    layout.append(identity, side);
+    contestantCell.append(layout);
+
+    const metric = getMetricPresentation(
+      this.payload.contest.format,
+      contestant,
+      this.payload.contest.points_precision,
+    );
+    const score = element("td", "resolver-metric resolver-metric--score user-points");
+    score.append(element("span", "resolver-summary-score", metric.score));
+    if (this.payload.contest.format !== "icpc") {
+      score.append(element("div", "solving-time resolver-summary-time", metric.time));
+    }
+    score.dataset.label = metric.scoreLabel;
+    row.append(rank, contestantCell, score);
+    if (this.payload.contest.format === "icpc") {
+      const time = element("td", "resolver-metric resolver-metric--time user-penalty", metric.time);
+      time.dataset.label = metric.timeLabel;
+      row.append(time);
+    }
+
+    this.problems.forEach((problem) => {
+      const problemId = normalizedId(problem.id);
+      const cell = contestant.problems[problemId];
+      const view = getCellPresentation(
+        this.payload.contest.format,
+        cell,
+        this.payload.contest.points_precision,
+      );
+      const tableCell = element("td", `resolver-cell resolver-cell--${view.state}`);
+      const sourceStateClass = {
+        solved: "full-score",
+        partial: "partial-score",
+        failed: "failed-score",
+        pending: "pending",
+      }[view.state];
+      if (sourceStateClass) {
+        tableCell.classList.add(sourceStateClass);
+      }
+      tableCell.dataset.problemId = problem.id;
+      tableCell.dataset.label = problem.label;
+      const stat = statsByProblem.get(problemId);
+      if (
+        view.state === "solved" &&
+        stat &&
+        normalizedId(stat.firstSolveContestantId) === normalizedId(contestant.participationId)
+      ) {
+        tableCell.classList.add("resolver-cell--first-solve", "first-solve");
+      }
+      if (
+        nextTarget &&
+        normalizedId(nextTarget.contestantId) === normalizedId(contestant.participationId) &&
+        normalizedId(nextTarget.problemId) === problemId
+      ) {
+        tableCell.classList.add("resolver-cell--target");
+      }
+
+      const content = view.resolvable
+        ? element("button", "resolver-cell__button")
+        : element("div", "resolver-cell__result");
+      if (view.resolvable) {
+        content.type = "button";
+        content.dataset.resolverAction = "reveal-cell";
+        content.dataset.contestantId = contestant.participationId;
+        content.dataset.problemId = problem.id;
+        content.setAttribute(
+          "aria-label",
+          `Reveal ${contestant.username}, problem ${problem.label}`,
+        );
+        content.disabled = this.busy;
+      } else {
+        content.setAttribute("aria-label", view.accessibleLabel);
+      }
+      content.append(element("span", "resolver-cell__primary", view.primary));
+      if (view.secondary) {
+        content.append(element("span", "resolver-cell__secondary", view.secondary));
+      }
+      tableCell.append(content);
+      row.append(tableCell);
+    });
+    return row;
+  }
+
+  _renderTotals(stats) {
+    const row = element("tr", "resolver-total-row");
+    const label = element("td", "resolver-total-label", "Total AC");
+    label.colSpan = this.payload.contest.format === "icpc" ? 4 : 3;
+    row.append(label);
+    stats.forEach((stat) => {
+      const total = element("td", "resolver-total total-ac", String(stat.totalSolved));
+      total.dataset.problemId = stat.problemId;
+      row.append(total);
+    });
+    this.nodes.tableFoot.replaceChildren(row);
+  }
+
+  _renderControls(nextTarget) {
+    if (!this.session) {
+      return;
+    }
+    const history = this.session.getHistory();
+    const remaining = this.session.getResolvableCells().length;
+    const revealed = this.totalResolvable - remaining;
+    const autoplay = this.autoplay.getState();
+    this.nodes.progress.textContent = `${revealed} / ${this.totalResolvable} cells resolved`;
+    this.nodes.status.textContent = remaining
+      ? this.statusMessage
+      : "Resolver complete — final standings reached.";
+    this.nodes.play.innerHTML = autoplay.playing
+      ? '<i class="fa fa-pause"></i> Pause'
+      : '<i class="fa fa-play"></i> Play';
+    this.nodes.play.disabled = this.policyName === "manual" || (!nextTarget && !autoplay.playing);
+    this.nodes.play.setAttribute("aria-pressed", String(autoplay.playing));
+    this.nodes.speedLabel.textContent = autoplay.speed.label;
+    this.nodes.slower.disabled = autoplay.speedIndex === 0;
+    this.nodes.faster.disabled = autoplay.speedIndex === 3;
+    this.nodes.back.disabled = this.busy || history.cursor === 0;
+    this.nodes.forward.disabled = this.busy || history.cursor >= history.transitions.length;
+    this.nodes.reset.disabled = this.busy || history.cursor === 0;
+    this.nodes.replay.disabled = this.busy || this.totalResolvable === 0;
+    this.nodes.changeSetup.disabled = this.busy;
+    this.nodes.next.disabled =
+      this.busy || autoplay.playing || this.policyName === "manual" || !nextTarget;
+    this.nodes.next.textContent =
+      this.granularity === "contestant" ? "Reveal next contestant" : "Reveal next cell";
+    this.nodes.toggleHud.setAttribute("aria-pressed", String(this.hudVisible));
+    this.nodes.hud.hidden = !this.hudVisible;
+    this.nodes.fullscreen.innerHTML = document.fullscreenElement
+      ? '<i class="fa fa-compress"></i> Exit fullscreen'
+      : '<i class="fa fa-expand"></i> Fullscreen';
+    this._renderHud(nextTarget, history, autoplay);
+  }
+
+  _renderHud(nextTarget, history, autoplay) {
+    const baseline = this.session.baseline === "official-freeze" ? "Freeze" : "Beginning";
+    const playback = autoplay.playing
+      ? `playing ${autoplay.speed.label}`
+      : `paused ${autoplay.speed.label}`;
+    this.nodes.hudMode.textContent = `${baseline} · ${
+      POLICY_LABELS[this.policyName]
+    } · ${playback}`;
+    if (nextTarget) {
+      const contestant = this.payload.contestants.find(
+        (entry) => normalizedId(entry.participation_id) === normalizedId(nextTarget.contestantId),
+      );
+      const problem = this.problems.find(
+        (entry) => normalizedId(entry.id) === normalizedId(nextTarget.problemId),
+      );
+      this.nodes.hudTarget.textContent = `${contestant?.username ?? nextTarget.contestantId} / ${
+        problem?.label ?? nextTarget.problemId
+      }`;
+    } else {
+      this.nodes.hudTarget.textContent = "—";
+    }
+    this.nodes.hudHistory.textContent = `${history.cursor} / ${history.transitions.length}`;
+    this.nodes.hudAward.textContent = this.awardPlaces ? `Top ${this.awardPlaces}` : "Off";
+    this.nodes.hudSeed.textContent = this.session.seed;
+  }
+
+  _selectTarget() {
+    return this.session && this.policyName !== "manual" ? this.policy.select(this.session) : null;
+  }
+
+  _resolvableForContestant(contestantId) {
+    return this.session
+      .getResolvableCells()
+      .filter((cell) => normalizedId(cell.contestantId) === normalizedId(contestantId));
+  }
+
+  async _stepFromOperator(label) {
+    this._pauseAutoplay();
+    await this._revealNext(label);
+  }
+
+  async _revealNext(label = "Reveal") {
+    if (this.busy || this.policyName === "manual") {
+      return null;
+    }
+    const target = this.policy.select(this.session);
+    if (!target) {
+      return null;
+    }
+    if (this.granularity === "contestant") {
+      return this._revealContestant(target.contestantId, `${label}, contestant`);
+    }
+    return this._revealTargets([target], `${label}, cell`);
+  }
+
+  async _revealContestant(contestantId, label) {
+    const targets = this._resolvableForContestant(contestantId);
+    return targets.length ? this._revealTargets(targets, label) : null;
+  }
+
+  async _revealTargets(targets, label) {
+    if (this.busy || !targets.length) {
+      return null;
+    }
+    this.busy = true;
+    const previousPositions = captureRowPositions(this.nodes.tableBody);
+    const transitions = [];
+    targets.forEach((target) => {
+      const transition = this.session.revealCell(target.contestantId, target.problemId);
+      if (transition) {
+        transitions.push(transition);
+      }
+    });
+    this.statusMessage = `${label}: ${transitions.length} ${
+      transitions.length === 1 ? "cell" : "cells"
+    }.`;
+    this._render();
+    await Promise.all([
+      animateRows(this.nodes.tableBody, previousPositions),
+      animateChangedCells(
+        this.nodes.tableBody,
+        transitions.map((transition) => transition.target),
+      ),
+    ]);
+    this.busy = false;
+    this._render();
+    return { transitions };
+  }
+
+  async _autoplayStep() {
+    const result = await this._revealNext("Autoplay");
+    if (!result) {
+      return { complete: true, pauseReason: null };
+    }
+    const complete = this.session.getResolvableCells().length === 0;
+    return {
+      complete,
+      pauseReason: complete
+        ? null
+        : getPauseReason(result.transitions, this.pauseBeats, this.awardPlaces),
+    };
+  }
+
+  _toggleAutoplay() {
+    if (this.policyName === "manual") {
+      return;
+    }
+    if (this.autoplay.playing) {
+      this.autoplay.pause();
+      return;
+    }
+    if (this.busy) {
+      return;
+    }
+    this.autoplay.toggle();
+  }
+
+  _pauseAutoplay(reason = "Autoplay paused.") {
+    if (this.autoplay.playing) {
+      this.autoplay.pause(reason, "operator");
+    }
+  }
+
+  _onAutoplayChange(state) {
+    if (!this.session) {
+      return;
+    }
+    if (state.playing) {
+      this.statusMessage = `Autoplay running at ${state.speed.label}.`;
+    } else if (state.pauseKind === "beat") {
+      this.statusMessage = `Paused on ceremony beat — ${state.pauseReason} Press Space to resume.`;
+    } else if (state.pauseKind === "complete") {
+      this.statusMessage = state.pauseReason;
+    } else if (state.pauseReason) {
+      this.statusMessage = state.pauseReason;
+    }
+    this._render();
+  }
+
+  async _moveHistory(direction) {
+    if (this.busy) {
+      return;
+    }
+    const history = this.session.getHistory();
+    const transition =
+      direction === "back"
+        ? history.transitions[history.cursor - 1]
+        : history.transitions[history.cursor];
+    if (!transition) {
+      return;
+    }
+    this.busy = true;
+    const previousPositions = captureRowPositions(this.nodes.tableBody);
+    const moved = direction === "back" ? this.session.back() : this.session.forward();
+    this.policy.clear();
+    if (moved) {
+      this.statusMessage =
+        direction === "back" ? "Stepped back one reveal." : "Stepped forward one reveal.";
+      this._render();
+      await Promise.all([
+        animateRows(this.nodes.tableBody, previousPositions),
+        animateChangedCells(this.nodes.tableBody, [transition.target]),
+      ]);
+    }
+    this.busy = false;
+    this._render();
+  }
+
+  async _reset(useReplay) {
+    if (this.busy) {
+      return;
+    }
+    this.busy = true;
+    const previousPositions = captureRowPositions(this.nodes.tableBody);
+    if (useReplay) {
+      this.session.replay();
+    } else {
+      this.session.reset();
+    }
+    this.policy.clear();
+    this.statusMessage = `${useReplay ? "Replay" : "Reset"} from ${this._baselineLabel()}.`;
+    this._render();
+    await animateRows(this.nodes.tableBody, previousPositions);
+    this.busy = false;
+    this._render();
+  }
+
+  async _replay() {
+    this._pauseAutoplay();
+    await this._reset(true);
+    if (this.policyName !== "manual" && this.session.getResolvableCells().length) {
+      this.autoplay.play();
+    }
+  }
+
+  _toggleHud() {
+    this.hudVisible = !this.hudVisible;
+    this._renderControls(this._selectTarget());
+  }
+
+  _showShortcuts() {
+    this.helpReturnFocus = document.activeElement;
+    this.nodes.shortcuts.hidden = false;
+    this.nodes.shortcutsClose.focus();
+  }
+
+  _hideShortcuts() {
+    if (this.nodes.shortcuts.hidden) {
+      return;
+    }
+    this.nodes.shortcuts.hidden = true;
+    if (this.helpReturnFocus instanceof HTMLElement) {
+      this.helpReturnFocus.focus();
+    }
+  }
+
+  async _toggleFullscreen() {
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await this.root.requestFullscreen();
+      }
+    } catch (error) {
+      this.statusMessage = `Fullscreen is unavailable: ${error.message}`;
+      this._render();
+    }
+  }
+
+  _handleShortcut(event) {
+    if (isTypingTarget(event.target)) {
+      return;
+    }
+    if (event.key === "Escape") {
+      if (!this.nodes.shortcuts.hidden) {
+        event.preventDefault();
+        this._hideShortcuts();
+      }
+      return;
+    }
+    if (this.nodes.workspace.hidden || !this.session) {
+      return;
+    }
+    const key = event.key.toLowerCase();
+    if (key === "?" || key === "/") {
+      event.preventDefault();
+      this._showShortcuts();
+      return;
+    }
+    if (event.repeat && !["[", "]", "arrowleft", "arrowright"].includes(key)) {
+      return;
+    }
+    if (key === "p") {
+      event.preventDefault();
+      this._toggleAutoplay();
+    } else if (key === " ") {
+      event.preventDefault();
+      if (this.autoplay.playing) {
+        this.autoplay.pause();
+      } else if (this.autoplay.pauseKind === "beat") {
+        this.autoplay.play();
+      } else {
+        void this._stepFromOperator("Keyboard step");
+      }
+    } else if (key === "[") {
+      event.preventDefault();
+      this.autoplay.slower();
+    } else if (key === "]") {
+      event.preventDefault();
+      this.autoplay.faster();
+    } else if (/^[1-4]$/.test(key)) {
+      event.preventDefault();
+      this.autoplay.setSpeed(Number(key) - 1);
+    } else if (key === "h") {
+      event.preventDefault();
+      this._toggleHud();
+    } else if (key === "f") {
+      event.preventDefault();
+      void this._toggleFullscreen();
+    } else if (key === "backspace" || key === "arrowleft") {
+      event.preventDefault();
+      this._pauseAutoplay();
+      void this._moveHistory("back");
+    } else if (key === "arrowright") {
+      event.preventDefault();
+      this._pauseAutoplay();
+      const history = this.session.getHistory();
+      if (history.cursor < history.transitions.length) {
+        void this._moveHistory("forward");
+      } else {
+        void this._revealNext("Keyboard next");
+      }
+    }
+  }
+}

--- a/resources/resolver/planner.js
+++ b/resources/resolver/planner.js
@@ -1,0 +1,141 @@
+import {
+  RESOLUTION_STEP_TYPES,
+  ScoreboardTiming,
+  SingleStepTiming,
+  usesSingleStepTiming,
+} from "./timing.js";
+
+function normalizeId(value) {
+  return String(value);
+}
+
+function countResolvableCells(state) {
+  return state.contestants.reduce(
+    (total, contestant) =>
+      total +
+      Object.values(contestant.problems).filter((cell) => cell.attempted && !cell.revealed).length,
+    0,
+  );
+}
+
+export function classifyResolutionResult(transition) {
+  if (transition.effects.positionAfter < transition.effects.positionBefore) {
+    return RESOLUTION_STEP_TYPES.RESULT_MOVE;
+  }
+  if (transition.effects.scoreImproved || transition.effects.cellPointsImproved) {
+    return RESOLUTION_STEP_TYPES.RESULT_STAY;
+  }
+  return RESOLUTION_STEP_TYPES.RESULT_FAILED;
+}
+
+function crossingBoundary(beforeRank, afterRank, boundary) {
+  return boundary > 0 && beforeRank > boundary && afterRank <= boundary;
+}
+
+export class ResolutionPlanner {
+  constructor({
+    payload,
+    targetSelector,
+    singleStepStartRank = 0,
+    awardPlaces = 0,
+    hardPauses = {},
+  }) {
+    this.payload = payload;
+    this.targetSelector = targetSelector;
+    this.singleStepStartRank = Number.parseInt(singleStepStartRank, 10) || 0;
+    this.awardPlaces = Number.parseInt(awardPlaces, 10) || 0;
+    this.hardPauses = {
+      singleStep: hardPauses.singleStep !== false,
+      award: hardPauses.award !== false,
+      firstSolve: hardPauses.firstSolve !== false,
+    };
+    this.scoreboardTiming = new ScoreboardTiming();
+    this.singleStepTiming = new SingleStepTiming();
+    this.contestants = new Map(
+      payload.contestants.map((contestant) => [
+        normalizeId(contestant.participation_id),
+        contestant,
+      ]),
+    );
+    this.problems = new Map(payload.problems.map((problem) => [normalizeId(problem.id), problem]));
+  }
+
+  projectNext(session) {
+    const target = this.targetSelector(session);
+    if (!target) {
+      return null;
+    }
+    const projection = session.projectReveal(target.contestantId, target.problemId);
+    if (!projection) {
+      return null;
+    }
+    const contestant = this.contestants.get(normalizeId(target.contestantId));
+    const problem = this.problems.get(normalizeId(target.problemId));
+    const { effects } = projection;
+    const resultType = classifyResolutionResult(projection);
+    const isSingleStep = usesSingleStepTiming(effects.rankBefore, this.singleStepStartRank);
+    const entersSingleStepZone = crossingBoundary(
+      effects.rankBefore,
+      effects.rankAfter,
+      this.singleStepStartRank,
+    );
+    const entersAwardZone = crossingBoundary(
+      effects.rankBefore,
+      effects.rankAfter,
+      this.awardPlaces,
+    );
+
+    let hardPauseKind = null;
+    let hardPauseReason = null;
+    if (this.hardPauses.firstSolve && effects.authoritativeFirstSolveAppeared) {
+      hardPauseKind = "first-solve";
+      hardPauseReason = `Authoritative first solve on problem ${
+        problem?.label ?? target.problemId
+      }.`;
+    } else if (this.hardPauses.award && entersAwardZone) {
+      hardPauseKind = "award-boundary";
+      hardPauseReason = `Entered the top ${this.awardPlaces} award zone.`;
+    } else if (this.hardPauses.singleStep && entersSingleStepZone) {
+      hardPauseKind = "single-step-boundary";
+      hardPauseReason = `Entered the top ${this.singleStepStartRank} single-step region.`;
+    }
+
+    return {
+      target: {
+        contestantId: target.contestantId,
+        problemId: target.problemId,
+      },
+      contestantLabel:
+        contestant?.display_name || contestant?.username || String(target.contestantId),
+      problemLabel: problem?.label ?? String(target.problemId),
+      currentPosition: effects.positionBefore,
+      currentRank: effects.rankBefore,
+      actualPositionAfterReveal: effects.positionAfter,
+      actualRankAfterReveal: effects.rankAfter,
+      movementDelta: effects.positionBefore - effects.positionAfter,
+      remainingUnresolvedCells: countResolvableCells(projection.after),
+      resultType,
+      isSingleStep,
+      entersSingleStepZone,
+      entersAwardZone,
+      authoritativeFirstSolve: effects.authoritativeFirstSolveAppeared,
+      hardPauseKind,
+      hardPauseReason,
+      projection,
+    };
+  }
+
+  planNext(session) {
+    const metadata = this.projectNext(session);
+    if (!metadata) {
+      return null;
+    }
+    const timing = metadata.isSingleStep ? this.singleStepTiming : this.scoreboardTiming;
+    return {
+      target: metadata.target,
+      metadata,
+      timing: metadata.isSingleStep ? "single-step" : "scoreboard",
+      steps: timing.buildSteps(metadata),
+    };
+  }
+}

--- a/resources/resolver/player.js
+++ b/resources/resolver/player.js
@@ -1,0 +1,348 @@
+import { effectiveDelay, RESOLUTION_STEP_TYPES } from "./timing.js";
+import { clone } from "./utils.js";
+
+const RESULT_TYPES = new Set([
+  RESOLUTION_STEP_TYPES.RESULT_MOVE,
+  RESOLUTION_STEP_TYPES.RESULT_STAY,
+  RESOLUTION_STEP_TYPES.RESULT_FAILED,
+]);
+
+function sameTarget(left, right) {
+  return (
+    left &&
+    right &&
+    String(left.contestantId) === String(right.contestantId) &&
+    String(left.problemId) === String(right.problemId)
+  );
+}
+
+function createDelay(durationMs) {
+  let timer = null;
+  let finish = null;
+  return {
+    promise: new Promise((resolve) => {
+      finish = resolve;
+      timer = globalThis.setTimeout(resolve, durationMs);
+    }),
+    cancel() {
+      if (timer !== null) {
+        globalThis.clearTimeout(timer);
+        timer = null;
+        finish();
+      }
+    },
+  };
+}
+
+function initialPresentation() {
+  return {
+    selectedContestantId: null,
+    selectedProblemId: null,
+    resultType: null,
+  };
+}
+
+export class ResolutionPlayer {
+  constructor({
+    session,
+    planner,
+    playbackSpeed = 1,
+    wait = null,
+    onBeforeStep = async () => null,
+    onStep = async () => {},
+    onRestore = async () => {},
+    onChange = () => {},
+  }) {
+    this.session = session;
+    this.planner = planner;
+    this.playbackSpeed = playbackSpeed;
+    this.wait = wait;
+    this.onBeforeStep = onBeforeStep;
+    this.onStep = onStep;
+    this.onRestore = onRestore;
+    this.onChange = onChange;
+
+    this.running = false;
+    this.complete = false;
+    this.pauseKind = "idle";
+    this.pauseReason = null;
+    this.presentation = initialPresentation();
+    this._plan = null;
+    this._cursor = 0;
+    this._runSerial = 0;
+    this._activeDelay = null;
+    this._activeRun = null;
+    this._checkpoints = [this._makeCheckpoint("beginning", "Resolver beginning")];
+    this._checkpointIndex = 0;
+    this._atCheckpoint = true;
+  }
+
+  _makeCheckpoint(kind, reason) {
+    return {
+      kind,
+      reason,
+      historyCursor: this.session.getHistory().cursor,
+      plan: this._plan,
+      cursor: this._cursor,
+      presentation: clone(this.presentation),
+    };
+  }
+
+  _notify() {
+    this.onChange(this.getState());
+  }
+
+  getState() {
+    return {
+      running: this.running,
+      complete: this.complete,
+      pauseKind: this.pauseKind,
+      pauseReason: this.pauseReason,
+      playbackSpeed: this.playbackSpeed,
+      presentation: clone(this.presentation),
+      checkpointIndex: this._checkpointIndex,
+      checkpointCount: this._checkpoints.length,
+      timing: this._plan?.timing ?? null,
+      projection: this._plan
+        ? {
+            ...this._plan.metadata,
+            projection: undefined,
+          }
+        : null,
+    };
+  }
+
+  setSpeed(playbackSpeed) {
+    const speed = Number(playbackSpeed);
+    if (!Number.isFinite(speed) || speed <= 0) {
+      throw new RangeError("Resolver playback speed must be greater than zero.");
+    }
+    this.playbackSpeed = speed;
+    this._notify();
+    return this.getState();
+  }
+
+  cancel(reason = "Playback paused.", kind = "operator") {
+    this._runSerial += 1;
+    this.running = false;
+    this.pauseKind = kind;
+    this.pauseReason = reason;
+    if (this._activeDelay) {
+      this._activeDelay.cancel();
+      this._activeDelay = null;
+    }
+    this._notify();
+  }
+
+  async _wait(durationMs, serial) {
+    if (this.wait) {
+      await this.wait(durationMs);
+      return;
+    }
+    this._activeDelay = createDelay(durationMs);
+    await this._activeDelay.promise;
+    if (serial === this._runSerial) {
+      this._activeDelay = null;
+    }
+  }
+
+  _updatePresentation(step) {
+    if (step.type === RESOLUTION_STEP_TYPES.SELECT_TEAM) {
+      this.presentation.selectedContestantId = step.target.contestantId;
+      this.presentation.selectedProblemId = null;
+      this.presentation.resultType = null;
+    } else if (step.type === RESOLUTION_STEP_TYPES.SELECT_PROBLEM) {
+      this.presentation.selectedContestantId = step.target.contestantId;
+      this.presentation.selectedProblemId = step.target.problemId;
+      this.presentation.resultType = null;
+    } else if (RESULT_TYPES.has(step.type)) {
+      this.presentation.resultType = step.type;
+    } else if (step.type === RESOLUTION_STEP_TYPES.DESELECT) {
+      this.presentation = initialPresentation();
+    }
+  }
+
+  _applyReveal(target) {
+    const history = this.session.getHistory();
+    const redo = history.transitions[history.cursor];
+    if (redo && sameTarget(redo.target, target)) {
+      this.session.forward();
+      return redo;
+    }
+    return this.session.revealCell(target.contestantId, target.problemId);
+  }
+
+  _recordPause(step) {
+    if (this._checkpointIndex < this._checkpoints.length - 1) {
+      this._checkpoints.splice(this._checkpointIndex + 1);
+    }
+    this._checkpoints.push(this._makeCheckpoint(step.kind, step.reason));
+    this._checkpointIndex = this._checkpoints.length - 1;
+    this._atCheckpoint = true;
+  }
+
+  async _executeStep(step, includeDelays, serial) {
+    if (step.type === RESOLUTION_STEP_TYPES.DELAY) {
+      if (includeDelays && step.durationMs > 0) {
+        await this._wait(effectiveDelay(step.durationMs, this.playbackSpeed), serial);
+      }
+      return null;
+    }
+
+    const beforeContext = await this.onBeforeStep(step, {
+      plan: this._plan,
+      presentation: clone(this.presentation),
+    });
+    let transition = null;
+    if (step.type === RESOLUTION_STEP_TYPES.REVEAL_CELL) {
+      transition = this._applyReveal(step.target);
+      if (!transition) {
+        throw new Error("Resolution plan targeted a cell that is no longer resolvable.");
+      }
+    }
+    this._updatePresentation(step);
+    await this.onStep(step, {
+      beforeContext,
+      plan: this._plan,
+      presentation: clone(this.presentation),
+      transition,
+    });
+
+    if (step.type === RESOLUTION_STEP_TYPES.PAUSE) {
+      this.pauseKind = step.kind;
+      this.pauseReason = step.reason;
+      this._recordPause(step);
+      return step;
+    }
+    return null;
+  }
+
+  async _run(serial, includeDelays) {
+    while (serial === this._runSerial) {
+      if (!this._plan || this._cursor >= this._plan.steps.length) {
+        this._plan = this.planner.planNext(this.session);
+        this._cursor = 0;
+        if (!this._plan) {
+          this.complete = true;
+          this.pauseKind = "complete";
+          this.pauseReason = "Resolver complete — final standings reached.";
+          return { complete: true, pause: null };
+        }
+      }
+
+      const step = this._plan.steps[this._cursor];
+      this._cursor += 1;
+      const pause = await this._executeStep(step, includeDelays, serial);
+      if (serial !== this._runSerial) {
+        return { complete: false, cancelled: true, pause: null };
+      }
+      if (pause) {
+        return { complete: false, pause };
+      }
+    }
+    return { complete: false, cancelled: true, pause: null };
+  }
+
+  playToNextPause(includeDelays = true) {
+    if (this.running) {
+      return this._activeRun;
+    }
+    this.running = true;
+    this.complete = false;
+    this.pauseKind = null;
+    this.pauseReason = null;
+    this._atCheckpoint = false;
+    const serial = ++this._runSerial;
+    this._notify();
+    this._activeRun = this._run(serial, includeDelays).finally(() => {
+      if (serial === this._runSerial) {
+        this.running = false;
+        this._activeRun = null;
+        this._notify();
+      }
+    });
+    return this._activeRun;
+  }
+
+  fastForwardToNextPause() {
+    return this.playToNextPause(false);
+  }
+
+  _restoreHistoryCursor(targetCursor) {
+    let history = this.session.getHistory();
+    while (history.cursor > targetCursor) {
+      if (!this.session.back()) {
+        throw new Error("Unable to rewind Resolver history to the requested pause.");
+      }
+      history = this.session.getHistory();
+    }
+    while (history.cursor < targetCursor) {
+      if (!this.session.forward()) {
+        throw new Error("Unable to replay Resolver history to the requested pause.");
+      }
+      history = this.session.getHistory();
+    }
+  }
+
+  async rewindToPreviousPause() {
+    if (this.running) {
+      this.cancel("Playback paused for rewind.", "operator");
+    }
+    const targetIndex = this._atCheckpoint
+      ? Math.max(0, this._checkpointIndex - 1)
+      : this._checkpointIndex;
+    const checkpoint = this._checkpoints[targetIndex];
+    this._restoreHistoryCursor(checkpoint.historyCursor);
+    this._plan = checkpoint.plan;
+    this._cursor = checkpoint.cursor;
+    this.presentation = clone(checkpoint.presentation);
+    this.complete = false;
+    this.pauseKind = checkpoint.kind;
+    this.pauseReason = checkpoint.reason;
+    this._checkpointIndex = targetIndex;
+    this._atCheckpoint = true;
+    await this.onRestore(this.getState());
+    this._notify();
+    return this.getState();
+  }
+
+  async resetToBeginning() {
+    if (this.running) {
+      this.cancel("Playback reset.", "operator");
+    }
+    this.session.reset();
+    this._plan = null;
+    this._cursor = 0;
+    this.presentation = initialPresentation();
+    this.complete = false;
+    this.pauseKind = "beginning";
+    this.pauseReason = "Resolver beginning";
+    this._checkpoints = [this._makeCheckpoint("beginning", "Resolver beginning")];
+    this._checkpointIndex = 0;
+    this._atCheckpoint = true;
+    await this.onRestore(this.getState());
+    this._notify();
+    return this.getState();
+  }
+
+  async syncAfterExternalChange(reason = "Resolver state changed manually.") {
+    if (this.running) {
+      this.cancel(reason, "manual");
+    }
+    this._plan = null;
+    this._cursor = 0;
+    this.presentation = initialPresentation();
+    this.complete = false;
+    this.pauseKind = "manual";
+    this.pauseReason = reason;
+    if (this._checkpointIndex < this._checkpoints.length - 1) {
+      this._checkpoints.splice(this._checkpointIndex + 1);
+    }
+    this._checkpoints.push(this._makeCheckpoint("manual", reason));
+    this._checkpointIndex = this._checkpoints.length - 1;
+    this._atCheckpoint = true;
+    await this.onRestore(this.getState());
+    this._notify();
+    return this.getState();
+  }
+}

--- a/resources/resolver/policies.js
+++ b/resources/resolver/policies.js
@@ -1,0 +1,154 @@
+function normalizeId(value) {
+  return String(value);
+}
+
+export function selectBottomUpStickyTarget(standings, resolvableCells, stickyContestantId = null) {
+  const cellsByContestant = new Map();
+  resolvableCells.forEach((cell) => {
+    const contestantId = normalizeId(cell.contestantId);
+    if (!cellsByContestant.has(contestantId)) {
+      cellsByContestant.set(contestantId, []);
+    }
+    cellsByContestant.get(contestantId).push(cell);
+  });
+
+  if (stickyContestantId !== null) {
+    const stickyCells = cellsByContestant.get(normalizeId(stickyContestantId));
+    if (stickyCells && stickyCells.length) {
+      return stickyCells[0];
+    }
+  }
+
+  for (let index = standings.length - 1; index >= 0; index -= 1) {
+    const cells = cellsByContestant.get(normalizeId(standings[index].contestantId));
+    if (cells && cells.length) {
+      return cells[0];
+    }
+  }
+  return null;
+}
+
+export class BottomUpStickyPolicy {
+  constructor() {
+    this.stickyContestantId = null;
+  }
+
+  select(session) {
+    const target = selectBottomUpStickyTarget(
+      session.getState().standings,
+      session.getResolvableCells(),
+      this.stickyContestantId,
+    );
+    this.stickyContestantId = target ? target.contestantId : null;
+    return target;
+  }
+
+  clear() {
+    this.stickyContestantId = null;
+  }
+}
+
+function selectCellForProblem(standings, resolvableCells, problemId) {
+  const contestants = new Set(
+    resolvableCells
+      .filter((cell) => normalizeId(cell.problemId) === normalizeId(problemId))
+      .map((cell) => normalizeId(cell.contestantId)),
+  );
+  for (let index = standings.length - 1; index >= 0; index -= 1) {
+    if (contestants.has(normalizeId(standings[index].contestantId))) {
+      return resolvableCells.find(
+        (cell) =>
+          normalizeId(cell.problemId) === normalizeId(problemId) &&
+          normalizeId(cell.contestantId) === normalizeId(standings[index].contestantId),
+      );
+    }
+  }
+  return null;
+}
+
+export function selectByProblemTarget(
+  standings,
+  resolvableCells,
+  problemOrder,
+  stickyProblemId = null,
+) {
+  if (stickyProblemId !== null) {
+    const stickyTarget = selectCellForProblem(standings, resolvableCells, stickyProblemId);
+    if (stickyTarget) {
+      return stickyTarget;
+    }
+  }
+  for (const problemId of problemOrder) {
+    const target = selectCellForProblem(standings, resolvableCells, problemId);
+    if (target) {
+      return target;
+    }
+  }
+  return null;
+}
+
+export class ByProblemPolicy {
+  constructor(problemOrder) {
+    this.problemOrder = [...problemOrder];
+    this.stickyProblemId = null;
+  }
+
+  select(session) {
+    const target = selectByProblemTarget(
+      session.getState().standings,
+      session.getResolvableCells(),
+      this.problemOrder,
+      this.stickyProblemId,
+    );
+    this.stickyProblemId = target ? target.problemId : null;
+    return target;
+  }
+
+  clear() {
+    this.stickyProblemId = null;
+  }
+}
+
+export function selectByContestantTarget(standings, resolvableCells, stickyContestantId = null) {
+  const cellsByContestant = new Map();
+  resolvableCells.forEach((cell) => {
+    const contestantId = normalizeId(cell.contestantId);
+    if (!cellsByContestant.has(contestantId)) {
+      cellsByContestant.set(contestantId, []);
+    }
+    cellsByContestant.get(contestantId).push(cell);
+  });
+  if (stickyContestantId !== null) {
+    const stickyCells = cellsByContestant.get(normalizeId(stickyContestantId));
+    if (stickyCells?.length) {
+      return stickyCells[0];
+    }
+  }
+  for (const standing of standings) {
+    const cells = cellsByContestant.get(normalizeId(standing.contestantId));
+    if (cells?.length) {
+      return cells[0];
+    }
+  }
+  return null;
+}
+
+export class ByContestantPolicy {
+  constructor() {
+    this.stickyContestantId = null;
+  }
+
+  select(session) {
+    const target = selectByContestantTarget(
+      session.getState().standings,
+      session.getResolvableCells(),
+      this.stickyContestantId,
+    );
+    this.stickyContestantId = target ? target.contestantId : null;
+    return target;
+  }
+
+  clear() {
+    this.stickyContestantId = null;
+  }
+}

--- a/resources/resolver/policies.js
+++ b/resources/resolver/policies.js
@@ -2,6 +2,87 @@ function normalizeId(value) {
   return String(value);
 }
 
+function lastRevealedTarget(session) {
+  const history = session.getHistory();
+  return history.cursor ? history.transitions[history.cursor - 1]?.target ?? null : null;
+}
+
+function orderedContestantCells(cells, problemOrder) {
+  const order = new Map(problemOrder.map((problemId, index) => [normalizeId(problemId), index]));
+  return [...cells].sort(
+    (left, right) =>
+      (order.get(normalizeId(left.problemId)) ?? Number.MAX_SAFE_INTEGER) -
+        (order.get(normalizeId(right.problemId)) ?? Number.MAX_SAFE_INTEGER) ||
+      normalizeId(left.problemId).localeCompare(normalizeId(right.problemId)),
+  );
+}
+
+function predeterminedProblemFor(predeterminedProblems, contestantId) {
+  if (predeterminedProblems instanceof Map) {
+    return (
+      predeterminedProblems.get(contestantId) ??
+      predeterminedProblems.get(normalizeId(contestantId))
+    );
+  }
+  return (
+    predeterminedProblems?.[contestantId] ?? predeterminedProblems?.[normalizeId(contestantId)]
+  );
+}
+
+export function selectRowSweepTarget(
+  standings,
+  resolvableCells,
+  problemOrder,
+  predeterminedProblems = {},
+) {
+  const cellsByContestant = new Map();
+  resolvableCells.forEach((cell) => {
+    const contestantId = normalizeId(cell.contestantId);
+    if (!cellsByContestant.has(contestantId)) {
+      cellsByContestant.set(contestantId, []);
+    }
+    cellsByContestant.get(contestantId).push(cell);
+  });
+
+  for (let index = standings.length - 1; index >= 0; index -= 1) {
+    const standing = standings[index];
+    const cells = orderedContestantCells(
+      cellsByContestant.get(normalizeId(standing.contestantId)) ?? [],
+      problemOrder,
+    );
+    if (!cells.length) {
+      continue;
+    }
+    const predeterminedProblem = predeterminedProblemFor(
+      predeterminedProblems,
+      standing.contestantId,
+    );
+    const predetermined = cells.find(
+      (cell) => normalizeId(cell.problemId) === normalizeId(predeterminedProblem),
+    );
+    return predetermined ?? cells[0];
+  }
+  return null;
+}
+
+export class RowSweepPolicy {
+  constructor(problemOrder, predeterminedProblems = {}) {
+    this.problemOrder = [...problemOrder];
+    this.predeterminedProblems = predeterminedProblems;
+  }
+
+  select(session) {
+    return selectRowSweepTarget(
+      session.getState().standings,
+      session.getResolvableCells(),
+      this.problemOrder,
+      this.predeterminedProblems,
+    );
+  }
+
+  clear() {}
+}
+
 export function selectBottomUpStickyTarget(standings, resolvableCells, stickyContestantId = null) {
   const cellsByContestant = new Map();
   resolvableCells.forEach((cell) => {
@@ -29,23 +110,17 @@ export function selectBottomUpStickyTarget(standings, resolvableCells, stickyCon
 }
 
 export class BottomUpStickyPolicy {
-  constructor() {
-    this.stickyContestantId = null;
-  }
-
   select(session) {
+    const previous = lastRevealedTarget(session);
     const target = selectBottomUpStickyTarget(
       session.getState().standings,
       session.getResolvableCells(),
-      this.stickyContestantId,
+      previous?.contestantId ?? null,
     );
-    this.stickyContestantId = target ? target.contestantId : null;
     return target;
   }
 
-  clear() {
-    this.stickyContestantId = null;
-  }
+  clear() {}
 }
 
 function selectCellForProblem(standings, resolvableCells, problemId) {
@@ -90,23 +165,20 @@ export function selectByProblemTarget(
 export class ByProblemPolicy {
   constructor(problemOrder) {
     this.problemOrder = [...problemOrder];
-    this.stickyProblemId = null;
   }
 
   select(session) {
+    const previous = lastRevealedTarget(session);
     const target = selectByProblemTarget(
       session.getState().standings,
       session.getResolvableCells(),
       this.problemOrder,
-      this.stickyProblemId,
+      previous?.problemId ?? null,
     );
-    this.stickyProblemId = target ? target.problemId : null;
     return target;
   }
 
-  clear() {
-    this.stickyProblemId = null;
-  }
+  clear() {}
 }
 
 export function selectByContestantTarget(standings, resolvableCells, stickyContestantId = null) {
@@ -134,21 +206,15 @@ export function selectByContestantTarget(standings, resolvableCells, stickyConte
 }
 
 export class ByContestantPolicy {
-  constructor() {
-    this.stickyContestantId = null;
-  }
-
   select(session) {
+    const previous = lastRevealedTarget(session);
     const target = selectByContestantTarget(
       session.getState().standings,
       session.getResolvableCells(),
-      this.stickyContestantId,
+      previous?.contestantId ?? null,
     );
-    this.stickyContestantId = target ? target.contestantId : null;
     return target;
   }
 
-  clear() {
-    this.stickyContestantId = null;
-  }
+  clear() {}
 }

--- a/resources/resolver/presentation.js
+++ b/resources/resolver/presentation.js
@@ -1,0 +1,209 @@
+function numeric(value) {
+  return Number(value ?? 0);
+}
+
+export function formatScore(value, precision = 3) {
+  const number = numeric(value);
+  if (Number.isInteger(number)) {
+    return String(number);
+  }
+  return number.toFixed(precision).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+export function formatDuration(seconds) {
+  const total = Math.max(0, Math.trunc(numeric(seconds)));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const remainingSeconds = total % 60;
+  if (hours) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(remainingSeconds).padStart(
+      2,
+      "0",
+    )}`;
+  }
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
+}
+
+function attemptLabel(count) {
+  return `${count} ${count === 1 ? "try" : "tries"}`;
+}
+
+function baseCellPresentation(cell) {
+  return {
+    state: cell.state,
+    primary: "—",
+    secondary: "",
+    accessibleLabel: "No submissions",
+    resolvable: cell.attempted && !cell.revealed,
+  };
+}
+
+function presentICPC(cell) {
+  const view = baseCellPresentation(cell);
+  if (cell.state === "empty") {
+    return view;
+  }
+  if (cell.state === "hidden") {
+    return {
+      ...view,
+      primary: "?",
+      secondary: "Unrevealed",
+      accessibleLabel: "Unrevealed result",
+    };
+  }
+  if (cell.state === "pending") {
+    const tries = numeric(cell.tries);
+    return {
+      ...view,
+      primary: tries ? attemptLabel(tries) : "?",
+      secondary: "Pending",
+      accessibleLabel: tries ? `${attemptLabel(tries)}, pending` : "Pending result",
+    };
+  }
+  if (cell.state === "failed") {
+    const tries = numeric(cell.tries);
+    return {
+      ...view,
+      primary: attemptLabel(tries),
+      accessibleLabel: `${attemptLabel(tries)}, not solved`,
+    };
+  }
+
+  const minute = Math.floor(numeric(cell.time) / 60);
+  const tries = numeric(cell.tries);
+  return {
+    ...view,
+    primary: String(minute),
+    secondary: attemptLabel(tries),
+    accessibleLabel: `Solved at ${minute} minutes in ${attemptLabel(tries)}`,
+  };
+}
+
+function presentDefault(cell, precision) {
+  const view = baseCellPresentation(cell);
+  if (cell.state === "empty") {
+    return view;
+  }
+  if (cell.state === "hidden") {
+    return {
+      ...view,
+      primary: "?",
+      secondary: "Unrevealed",
+      accessibleLabel: "Unrevealed result",
+    };
+  }
+  const score = formatScore(cell.points, precision);
+  const time = formatDuration(cell.time);
+  return {
+    ...view,
+    primary: score,
+    secondary: time,
+    accessibleLabel: `${score} points at ${time}`,
+  };
+}
+
+function presentVNOJ(cell, precision) {
+  const view = baseCellPresentation(cell);
+  if (cell.state === "empty") {
+    return view;
+  }
+  if (cell.state === "hidden") {
+    return {
+      ...view,
+      primary: "?",
+      secondary: "Unrevealed",
+      accessibleLabel: "Unrevealed result",
+    };
+  }
+  if (cell.state === "pending") {
+    const known = numeric(cell.points) !== 0 || numeric(cell.penalty) !== 0;
+    const pending = numeric(cell.pending);
+    const primary = `${known ? `${formatScore(cell.points, precision)}?` : "?"}${
+      pending ? ` [${pending}]` : ""
+    }`;
+    return {
+      ...view,
+      primary,
+      secondary: "Pending",
+      accessibleLabel: `${primary}, pending result`,
+    };
+  }
+
+  const score = formatScore(cell.points, precision);
+  const penalty = numeric(cell.penalty);
+  const primary = penalty ? `${score} (+${penalty})` : score;
+  const time = formatDuration(cell.time);
+  return {
+    ...view,
+    primary,
+    secondary: time,
+    accessibleLabel: `${score} points${penalty ? ` with ${penalty} penalties` : ""} at ${time}`,
+  };
+}
+
+export function getCellPresentation(formatName, cell, precision = 3) {
+  if (formatName === "icpc") {
+    return presentICPC(cell);
+  }
+  if (formatName === "vnoj") {
+    return presentVNOJ(cell, precision);
+  }
+  if (formatName === "default") {
+    return presentDefault(cell, precision);
+  }
+  throw new RangeError(`Unsupported Resolver presentation format "${formatName}".`);
+}
+
+export function getMetricPresentation(formatName, contestant, precision = 3) {
+  if (formatName === "icpc") {
+    return {
+      scoreLabel: "Solved",
+      score: formatScore(contestant.score, precision),
+      timeLabel: "Penalty",
+      time: String(Math.trunc(numeric(contestant.cumtime))),
+    };
+  }
+  return {
+    scoreLabel: "Score",
+    score: formatScore(contestant.score, precision),
+    timeLabel: "Time",
+    time: formatDuration(contestant.cumtime),
+  };
+}
+
+export function deriveProblemStats(payload, state) {
+  const contestants = new Map(
+    state.contestants.map((contestant) => [String(contestant.participationId), contestant]),
+  );
+
+  return [...payload.problems]
+    .sort(
+      (left, right) => left.order - right.order || String(left.id).localeCompare(String(right.id)),
+    )
+    .map((problem) => {
+      let totalSolved = 0;
+      let firstSolveContestantId = null;
+      let firstSolveTime = null;
+
+      state.contestants.forEach((contestant) => {
+        const cell = contestants.get(String(contestant.participationId)).problems[
+          String(problem.id)
+        ];
+        if (!cell || cell.state !== "solved") {
+          return;
+        }
+        totalSolved += 1;
+        if (firstSolveTime === null || numeric(cell.time) < firstSolveTime) {
+          firstSolveTime = numeric(cell.time);
+          firstSolveContestantId = contestant.participationId;
+        }
+      });
+
+      return {
+        problemId: problem.id,
+        totalSolved,
+        firstSolveContestantId,
+        firstSolveTime,
+      };
+    });
+}

--- a/resources/resolver/presentation.js
+++ b/resources/resolver/presentation.js
@@ -24,6 +24,29 @@ export function formatDuration(seconds) {
   return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
 }
 
+export function normalizeRankDisplayOption(value) {
+  const option = Number(value);
+  return option === 1 || option === 2 || option === 3 ? option : 3;
+}
+
+export function getOrganizationPresentation(organizations) {
+  if (!Array.isArray(organizations)) {
+    return [];
+  }
+  return organizations
+    .map((organization) => {
+      const label = organization?.short_name || organization?.name;
+      if (!label) {
+        return null;
+      }
+      return {
+        label: String(label),
+        url: organization.url ? String(organization.url) : null,
+      };
+    })
+    .filter(Boolean);
+}
+
 function attemptLabel(count) {
   return `${count} ${count === 1 ? "try" : "tries"}`;
 }
@@ -31,7 +54,7 @@ function attemptLabel(count) {
 function baseCellPresentation(cell) {
   return {
     state: cell.state,
-    primary: "—",
+    primary: "",
     secondary: "",
     accessibleLabel: "No submissions",
     resolvable: cell.attempted && !cell.revealed,
@@ -56,12 +79,20 @@ function presentICPC(cell) {
     return {
       ...view,
       primary: tries ? attemptLabel(tries) : "?",
-      secondary: "Pending",
+      secondary: "",
       accessibleLabel: tries ? `${attemptLabel(tries)}, pending` : "Pending result",
     };
   }
   if (cell.state === "failed") {
     const tries = numeric(cell.tries);
+    if (!tries) {
+      return {
+        ...view,
+        state: "empty",
+        primary: "",
+        accessibleLabel: "No countable submissions",
+      };
+    }
     return {
       ...view,
       primary: attemptLabel(tries),
@@ -75,6 +106,9 @@ function presentICPC(cell) {
     ...view,
     primary: String(minute),
     secondary: attemptLabel(tries),
+    minute,
+    tries,
+    time: formatDuration(cell.time),
     accessibleLabel: `Solved at ${minute} minutes in ${attemptLabel(tries)}`,
   };
 }
@@ -98,6 +132,7 @@ function presentDefault(cell, precision) {
     ...view,
     primary: score,
     secondary: time,
+    time,
     accessibleLabel: `${score} points at ${time}`,
   };
 }
@@ -118,25 +153,27 @@ function presentVNOJ(cell, precision) {
   if (cell.state === "pending") {
     const known = numeric(cell.points) !== 0 || numeric(cell.penalty) !== 0;
     const pending = numeric(cell.pending);
-    const primary = `${known ? `${formatScore(cell.points, precision)}?` : "?"}${
-      pending ? ` [${pending}]` : ""
-    }`;
+    const primary = known ? `${formatScore(cell.points, precision)}?` : "?";
     return {
       ...view,
       primary,
-      secondary: "Pending",
-      accessibleLabel: `${primary}, pending result`,
+      secondary: "?",
+      pendingCount: pending,
+      penalty: 0,
+      accessibleLabel: `${primary}${pending ? ` [${pending}]` : ""}, pending result`,
     };
   }
 
   const score = formatScore(cell.points, precision);
   const penalty = numeric(cell.penalty);
-  const primary = penalty ? `${score} (+${penalty})` : score;
   const time = formatDuration(cell.time);
   return {
     ...view,
-    primary,
+    primary: score,
     secondary: time,
+    penalty,
+    pendingCount: 0,
+    time,
     accessibleLabel: `${score} points${penalty ? ` with ${penalty} penalties` : ""} at ${time}`,
   };
 }
@@ -182,6 +219,7 @@ export function deriveProblemStats(payload, state) {
     )
     .map((problem) => {
       let totalSolved = 0;
+      const authoritativeFirstSolveContestantId = problem.first_solve_participation_id ?? null;
       let firstSolveContestantId = null;
       let firstSolveTime = null;
 
@@ -193,7 +231,10 @@ export function deriveProblemStats(payload, state) {
           return;
         }
         totalSolved += 1;
-        if (firstSolveTime === null || numeric(cell.time) < firstSolveTime) {
+        if (
+          authoritativeFirstSolveContestantId !== null &&
+          String(authoritativeFirstSolveContestantId) === String(contestant.participationId)
+        ) {
           firstSolveTime = numeric(cell.time);
           firstSolveContestantId = contestant.participationId;
         }

--- a/resources/resolver/ranking.js
+++ b/resources/resolver/ranking.js
@@ -30,7 +30,12 @@ export function createSourceOrderTieKeys(contestants) {
   );
 }
 
-export function compareContestants(left, right) {
+function fallbackOrder(contestant, fallback) {
+  const value = contestant[fallback];
+  return Number.isFinite(value) ? value : contestant.tieKey;
+}
+
+export function compareContestants(left, right, fallback = "tieKey") {
   if (left.isDisqualified !== right.isDisqualified) {
     return left.isDisqualified ? 1 : -1;
   }
@@ -43,7 +48,7 @@ export function compareContestants(left, right) {
   if (left.tiebreaker !== right.tiebreaker) {
     return left.tiebreaker - right.tiebreaker;
   }
-  return left.tieKey - right.tieKey;
+  return fallbackOrder(left, fallback) - fallbackOrder(right, fallback);
 }
 
 function sameDisplayedRank(left, right) {
@@ -54,8 +59,9 @@ function sameDisplayedRank(left, right) {
   );
 }
 
-export function rankContestants(contestants) {
-  const ordered = [...contestants].sort(compareContestants);
+export function rankContestants(contestants, options = {}) {
+  const fallback = options.fallback ?? "tieKey";
+  const ordered = [...contestants].sort((left, right) => compareContestants(left, right, fallback));
   let displayedRank = 0;
   let previous = null;
 

--- a/resources/resolver/ranking.js
+++ b/resources/resolver/ranking.js
@@ -1,0 +1,77 @@
+function hashText(text) {
+  let hash = 2166136261;
+  for (let index = 0; index < text.length; index++) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function createDeterministicTieKeys(contestants, seed) {
+  const shuffled = contestants
+    .map((contestant) => {
+      const id = String(contestant.participation_id ?? contestant.participationId);
+      return {
+        id,
+        hash: hashText(`${seed}\u0000${id}`),
+      };
+    })
+    .sort((left, right) => left.hash - right.hash || left.id.localeCompare(right.id));
+
+  return new Map(shuffled.map((entry, index) => [entry.id, index]));
+}
+
+export function createSourceOrderTieKeys(contestants) {
+  return new Map(
+    contestants.map((contestant, index) => [
+      String(contestant.participation_id ?? contestant.participationId),
+      index,
+    ]),
+  );
+}
+
+export function compareContestants(left, right) {
+  if (left.isDisqualified !== right.isDisqualified) {
+    return left.isDisqualified ? 1 : -1;
+  }
+  if (left.score !== right.score) {
+    return right.score - left.score;
+  }
+  if (left.cumtime !== right.cumtime) {
+    return left.cumtime - right.cumtime;
+  }
+  if (left.tiebreaker !== right.tiebreaker) {
+    return left.tiebreaker - right.tiebreaker;
+  }
+  return left.tieKey - right.tieKey;
+}
+
+function sameDisplayedRank(left, right) {
+  return (
+    left.score === right.score &&
+    left.cumtime === right.cumtime &&
+    left.tiebreaker === right.tiebreaker
+  );
+}
+
+export function rankContestants(contestants) {
+  const ordered = [...contestants].sort(compareContestants);
+  let displayedRank = 0;
+  let previous = null;
+
+  return ordered.map((contestant, index) => {
+    if (previous === null || !sameDisplayedRank(previous, contestant)) {
+      displayedRank = index + 1;
+    }
+    previous = contestant;
+    return {
+      contestantId: contestant.participationId,
+      position: index + 1,
+      rank: displayedRank,
+      score: contestant.score,
+      cumtime: contestant.cumtime,
+      tiebreaker: contestant.tiebreaker,
+      isDisqualified: contestant.isDisqualified,
+    };
+  });
+}

--- a/resources/resolver/resolver.css
+++ b/resources/resolver/resolver.css
@@ -249,20 +249,6 @@
   box-shadow: inset 4px 0 0 #337ab7;
 }
 
-#ranking-table.resolver-table .resolver-row--award > .resolver-rank,
-#ranking-table.resolver-table .resolver-row--award > .resolver-contestant,
-#ranking-table.resolver-table .resolver-row--award > .resolver-metric {
-  background-color: rgba(245, 193, 45, 0.14);
-}
-
-#ranking-table.resolver-table .resolver-row--award > .resolver-rank {
-  box-shadow: inset 3px 0 0 #d6a318;
-}
-
-#ranking-table.resolver-table .resolver-row--award-first > .resolver-rank {
-  box-shadow: inset 3px 0 0 #b8860b;
-}
-
 #ranking-table.resolver-table .resolver-row--moving {
   position: relative;
   z-index: 2;
@@ -304,6 +290,14 @@
   flex: 0 0 3.2rem;
 }
 
+.resolver-contestant__identity .resolver-contestant__visual--logo {
+  border-radius: 0.15rem;
+}
+
+.resolver-contestant__visual--logo img {
+  object-fit: contain;
+}
+
 .resolver-contestant__identity .u-logo-sep1 {
   flex: 0 0 0;
   height: 4em;
@@ -326,6 +320,10 @@
 
 .resolver-contestant__avatar {
   border-radius: 50%;
+}
+
+.resolver-contestant__logo {
+  border-radius: 0;
 }
 
 .resolver-contestant__handle {
@@ -351,36 +349,29 @@
 .resolver-contestant__side {
   flex: 0 0 auto;
   align-self: stretch;
-  min-width: 2.4em;
   text-align: right;
 }
 
 .resolver-contestant__organization {
-  max-width: 6em;
+  max-width: 13em;
   margin-top: 0.15em;
   color: #777;
   font-size: 0.75em;
   text-align: right;
 }
 
-.resolver-row-reveal {
-  border: 0;
-  background: transparent;
-  color: #333;
+#ranking-table.resolver-table .resolver-contestant[data-resolver-action] {
   cursor: pointer;
-  padding: 0.15em 0;
-  font: inherit;
 }
 
-.resolver-row-reveal:hover:not(:disabled),
-.resolver-row-reveal:focus-visible {
-  color: #337ab7;
-  outline: 0;
+#ranking-table.resolver-table .resolver-contestant[data-resolver-action]:hover,
+#ranking-table.resolver-table .resolver-contestant[data-resolver-action]:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(51, 122, 183, 0.65);
+  outline: none;
 }
 
-.resolver-row-reveal:disabled {
-  cursor: not-allowed;
-  opacity: 0.35;
+.resolver-contestant__organization a {
+  display: inline !important;
 }
 
 #ranking-table.resolver-table .resolver-metric {
@@ -403,13 +394,15 @@
 
 .resolver-cell__button,
 .resolver-cell__result {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
   box-sizing: border-box;
   width: 100%;
   min-height: 3.4em;
   border: 0;
   border-radius: 0;
-  place-content: center;
   background: transparent !important;
   color: inherit !important;
   padding: 0.25em 0.35em;
@@ -438,10 +431,25 @@
 }
 
 .resolver-cell__secondary {
+  flex-basis: 100%;
   color: inherit;
   font-size: 0.7em;
   font-weight: 400;
   opacity: 0.7;
+}
+
+.resolver-cell__primary.solving-time-minute {
+  font-size: 1.25em;
+}
+
+.resolver-cell__penalty {
+  color: red;
+  font-size: 0.72em;
+}
+
+.resolver-cell__pending-count {
+  color: black;
+  font-size: 0.72em;
 }
 
 #ranking-table.resolver-table .resolver-cell--hidden {
@@ -453,17 +461,8 @@
   box-shadow: inset 0 0 0 3px #337ab7;
 }
 
-.resolver-cell--first-solve .resolver-cell__primary::after {
-  content: " ★";
-  font-size: 0.72em;
-}
-
 #ranking-table.resolver-table .resolver-cell--changed {
   animation: resolver-cell-reveal 650ms ease-out;
-}
-
-.resolver-total-row > * {
-  background: rgba(0, 0, 0, 0.035);
 }
 
 .resolver-total-label {

--- a/resources/resolver/resolver.css
+++ b/resources/resolver/resolver.css
@@ -1,0 +1,622 @@
+.resolver-page {
+  color: #333;
+  padding-bottom: 1.25em;
+}
+
+.resolver-page[hidden],
+.resolver-page [hidden] {
+  display: none !important;
+}
+
+.resolver-setup {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.018);
+  padding: 1em 1.15em;
+}
+
+.resolver-setup__heading {
+  margin: 0 0 0.25em;
+  color: #444;
+  font-size: 1.25em;
+}
+
+.resolver-setup__heading .fa {
+  color: #337ab7;
+  margin-right: 0.25em;
+}
+
+.resolver-setup__intro {
+  margin: 0 0 1em;
+  color: #777;
+  font-size: 0.92em;
+}
+
+.resolver-setup__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8em 1.35em;
+  align-items: flex-start;
+}
+
+.resolver-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em;
+  margin-bottom: 0.85em;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 0.75em;
+}
+
+.resolver-presets [aria-pressed="true"] {
+  box-shadow: inset 0 -2px 0 #1d5680;
+  font-weight: 600;
+}
+
+.resolver-field {
+  display: grid;
+  flex: 1 1 200px;
+  gap: 0.3em;
+  max-width: 320px;
+}
+
+.resolver-field label {
+  color: #444;
+  font-weight: 600;
+}
+
+.resolver-field select,
+.resolver-field input[type="number"] {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.25em;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  background: #fff;
+  color: #444;
+  padding: 4px 7px;
+  font: inherit;
+}
+
+.resolver-field select:focus,
+.resolver-field input[type="number"]:focus {
+  border-color: rgba(82, 168, 236, 0.8);
+  box-shadow: 0 0 5px rgba(82, 168, 236, 0.45);
+  outline: 0;
+}
+
+.resolver-field--beats {
+  display: flex;
+  flex: 1 1 310px;
+  max-width: 480px;
+  margin: 0;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 0.45em 0.7em 0.6em;
+}
+
+.resolver-field--beats legend {
+  color: #444;
+  font-weight: 600;
+}
+
+.resolver-field--beats label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  margin-right: 0.7em;
+  font-size: 0.84em;
+  font-weight: 400;
+}
+
+.resolver-field__help {
+  color: #888;
+  font-size: 0.76em;
+  line-height: 1.35;
+}
+
+.resolver-setup__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  margin-top: 1em;
+  border-top: 1px solid #ddd;
+  padding-top: 0.8em;
+}
+
+.resolver-setup__note {
+  margin: 0;
+  color: #777;
+  font-size: 0.82em;
+}
+
+.resolver-button {
+  font-size: 0.9em;
+}
+
+.resolver-button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.8);
+  opacity: 0.48;
+}
+
+.resolver-button--row {
+  float: right;
+  margin-left: 0.6em;
+  padding: 3px 6px;
+}
+
+.resolver-button--compact {
+  min-width: 2em;
+  padding-right: 0.45em;
+  padding-left: 0.45em;
+}
+
+.resolver-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6em;
+  margin-bottom: 0.65em;
+}
+
+.resolver-toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.resolver-progress {
+  color: #555;
+  font-size: 0.86em;
+  font-weight: 600;
+}
+
+.resolver-speed-label {
+  min-width: 2.4em;
+  color: #555;
+  text-align: center;
+  font-size: 0.82em;
+  font-weight: 600;
+}
+
+.resolver-status {
+  min-height: 1.35em;
+  margin: 0 0 0.7em;
+  border-left: 3px solid #337ab7;
+  background: rgba(51, 122, 183, 0.07);
+  color: #666;
+  padding: 0.38em 0.65em;
+  font-size: 0.84em;
+}
+
+.resolver-hud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em 1.1em;
+  margin: -0.25em 0 0.7em;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.018);
+  color: #666;
+  padding: 0.45em 0.65em;
+  font-size: 0.78em;
+}
+
+.resolver-hud[hidden] {
+  display: none;
+}
+
+.resolver-hud code {
+  color: #555;
+}
+
+.resolver-table-wrap {
+  overflow-x: auto;
+}
+
+#ranking-table.resolver-table {
+  min-width: 680px;
+  font-size: 14px;
+}
+
+#ranking-table.resolver-table th,
+#ranking-table.resolver-table td {
+  height: 2.5em;
+}
+
+#ranking-table.resolver-table .resolver-heading--problem {
+  min-width: 3.6em;
+}
+
+.resolver-problem-label,
+.resolver-problem-denominator {
+  display: block;
+}
+
+.resolver-problem-label {
+  font-weight: 600;
+}
+
+.resolver-problem-denominator {
+  font-weight: 400;
+}
+
+#ranking-table.resolver-table .resolver-row--target {
+  box-shadow: inset 4px 0 0 #337ab7;
+}
+
+#ranking-table.resolver-table .resolver-row--award > .resolver-rank,
+#ranking-table.resolver-table .resolver-row--award > .resolver-contestant,
+#ranking-table.resolver-table .resolver-row--award > .resolver-metric {
+  background-color: rgba(245, 193, 45, 0.14);
+}
+
+#ranking-table.resolver-table .resolver-row--award > .resolver-rank {
+  box-shadow: inset 3px 0 0 #d6a318;
+}
+
+#ranking-table.resolver-table .resolver-row--award-first > .resolver-rank {
+  box-shadow: inset 3px 0 0 #b8860b;
+}
+
+#ranking-table.resolver-table .resolver-row--moving {
+  position: relative;
+  z-index: 2;
+  box-shadow: 0 5px 13px rgba(0, 0, 0, 0.18);
+}
+
+#ranking-table.resolver-table .resolver-row--disqualified {
+  opacity: 0.62;
+}
+
+#ranking-table.resolver-table .resolver-rank {
+  min-width: 2.4em;
+  font-weight: 600;
+}
+
+#ranking-table.resolver-table .resolver-contestant {
+  position: relative;
+  min-width: 20em;
+  padding-left: 0.75em;
+  text-align: left;
+}
+
+.resolver-contestant__layout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65em;
+  min-height: 4em;
+}
+
+.resolver-contestant__identity {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 1em;
+}
+
+.resolver-contestant__identity .u-logo-ranking {
+  flex: 0 0 3.2rem;
+}
+
+.resolver-contestant__identity .u-logo-sep1 {
+  flex: 0 0 0;
+  height: 4em;
+  margin-right: 0.1em;
+}
+
+.resolver-contestant__visual-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.resolver-contestant__names {
+  display: block;
+  min-width: 0;
+  line-height: 1.25;
+}
+
+.resolver-contestant__avatar {
+  border-radius: 50%;
+}
+
+.resolver-contestant__handle {
+  display: inline-block !important;
+  max-width: 13em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resolver-contestant__display,
+.resolver-contestant__organization {
+  display: block !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resolver-contestant__display {
+  max-width: 13em;
+}
+
+.resolver-contestant__side {
+  flex: 0 0 auto;
+  align-self: stretch;
+  min-width: 2.4em;
+  text-align: right;
+}
+
+.resolver-contestant__organization {
+  max-width: 6em;
+  margin-top: 0.15em;
+  color: #777;
+  font-size: 0.75em;
+  text-align: right;
+}
+
+.resolver-row-reveal {
+  border: 0;
+  background: transparent;
+  color: #333;
+  cursor: pointer;
+  padding: 0.15em 0;
+  font: inherit;
+}
+
+.resolver-row-reveal:hover:not(:disabled),
+.resolver-row-reveal:focus-visible {
+  color: #337ab7;
+  outline: 0;
+}
+
+.resolver-row-reveal:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+#ranking-table.resolver-table .resolver-metric {
+  min-width: 3.4em;
+  color: #333;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.resolver-summary-score,
+.resolver-summary-time {
+  display: block;
+}
+
+#ranking-table.resolver-table .resolver-cell {
+  min-width: 3.6em;
+  padding: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.resolver-cell__button,
+.resolver-cell__result {
+  display: grid;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 3.4em;
+  border: 0;
+  border-radius: 0;
+  place-content: center;
+  background: transparent !important;
+  color: inherit !important;
+  padding: 0.25em 0.35em;
+  font: inherit;
+  line-height: 1.25;
+}
+
+.resolver-cell__button {
+  cursor: pointer;
+}
+
+.resolver-cell__button:hover:not(:disabled),
+.resolver-cell__button:focus-visible {
+  box-shadow: inset 0 0 0 2px #337ab7;
+  outline: 0;
+}
+
+.resolver-cell__primary,
+.resolver-cell__secondary {
+  display: block;
+}
+
+.resolver-cell__primary {
+  font-size: 0.88em;
+  font-weight: 600;
+}
+
+.resolver-cell__secondary {
+  color: inherit;
+  font-size: 0.7em;
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+#ranking-table.resolver-table .resolver-cell--hidden {
+  background: rgba(0, 0, 0, 0.035);
+  color: #777;
+}
+
+#ranking-table.resolver-table .resolver-cell--target {
+  box-shadow: inset 0 0 0 3px #337ab7;
+}
+
+.resolver-cell--first-solve .resolver-cell__primary::after {
+  content: " ★";
+  font-size: 0.72em;
+}
+
+#ranking-table.resolver-table .resolver-cell--changed {
+  animation: resolver-cell-reveal 650ms ease-out;
+}
+
+.resolver-total-row > * {
+  background: rgba(0, 0, 0, 0.035);
+}
+
+.resolver-total-label {
+  text-align: right !important;
+  font-size: 0.82em;
+  text-transform: uppercase;
+}
+
+.resolver-total {
+  font-weight: 600;
+}
+
+.resolver-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  margin-top: 0.65em;
+  color: #777;
+  font-size: 0.75em;
+}
+
+.resolver-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+.resolver-legend__swatch {
+  width: 0.8em;
+  height: 0.8em;
+  border: 1px solid #aaa;
+}
+
+.resolver-legend__swatch--pending {
+  background: #b0e8f4;
+}
+
+.resolver-legend__swatch--solved {
+  background: #b7f993;
+}
+
+.resolver-legend__swatch--partial {
+  background: #f5f5f5;
+}
+
+.resolver-legend__swatch--failed {
+  background: #f4cccc;
+}
+
+.resolver-client-error {
+  border: 1px solid #d99;
+  background: #fee;
+  color: #933;
+  padding: 0.65em;
+}
+
+.resolver-overlay {
+  position: fixed;
+  z-index: 10000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.48);
+  padding: 1em;
+}
+
+.resolver-overlay[hidden] {
+  display: none;
+}
+
+.resolver-shortcuts {
+  box-sizing: border-box;
+  width: min(34em, 100%);
+  max-height: calc(100vh - 2em);
+  overflow-y: auto;
+  border: 1px solid #aaa;
+  border-radius: 3px;
+  background: #fff;
+  color: #444;
+  padding: 1em 1.1em;
+}
+
+.resolver-shortcuts__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 0.55em;
+}
+
+.resolver-shortcuts__heading h3 {
+  margin: 0;
+}
+
+.resolver-shortcuts__list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.45em 1em;
+  margin-bottom: 0;
+}
+
+.resolver-shortcuts__list dt {
+  font-family: monospace;
+  font-weight: 700;
+}
+
+.resolver-shortcuts__list dd {
+  margin: 0;
+}
+
+.resolver-page:fullscreen {
+  box-sizing: border-box;
+  overflow: auto;
+  background: #fff;
+  padding: 1em;
+}
+
+@keyframes resolver-cell-reveal {
+  0% {
+    box-shadow: inset 0 0 0 999px rgba(255, 255, 255, 0.78);
+    transform: scale(0.97);
+  }
+  55% {
+    transform: scale(1.025);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 700px) {
+  .resolver-setup__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .resolver-field {
+    max-width: none;
+  }
+
+  .resolver-setup__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resolver-page *,
+  .resolver-page *::before,
+  .resolver-page *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/resources/resolver/tests/fixtures.js
+++ b/resources/resolver/tests/fixtures.js
@@ -1,5 +1,14 @@
-function problem(id, code, label, order, maxScore = 100) {
-  return { id, code, label, name: `Problem ${label}`, order, max_score: maxScore };
+function problem(id, code, label, order, maxScore = 100, firstSolve = null, totalAc = 0) {
+  return {
+    id,
+    code,
+    label,
+    name: `Problem ${label}`,
+    order,
+    max_score: maxScore,
+    first_solve_participation_id: firstSolve,
+    final_total_ac: totalAc,
+  };
 }
 
 function contestant(id, name, final, problems, frozen = null, submissionCount = 0) {
@@ -8,8 +17,12 @@ function contestant(id, name, final, problems, frozen = null, submissionCount = 
     profile_id: id + 1000,
     username: name,
     display_name: name.toUpperCase(),
+    full_name: `${name} full name`,
+    user_css_class: "rating rate-none user",
+    profile_url: `/user/${name}`,
     avatar_url: null,
-    organization: null,
+    rank_logo_url: null,
+    organizations: [],
     is_disqualified: false,
     submission_count: submissionCount,
     final,
@@ -18,7 +31,26 @@ function contestant(id, name, final, problems, frozen = null, submissionCount = 
   };
 }
 
-function payload(format, formatConfig, problems, contestants, frozen = false) {
+function payload(
+  format,
+  formatConfig,
+  problems,
+  contestants,
+  frozen = false,
+  finalOrder = null,
+  frozenOrder = null,
+) {
+  const finalOrderMap = new Map(
+    (finalOrder ?? contestants.map((entry) => entry.participation_id)).map((id, index) => [
+      id,
+      index,
+    ]),
+  );
+  const frozenOrderMap = new Map(
+    (frozenOrder ?? finalOrder ?? contestants.map((entry) => entry.participation_id)).map(
+      (id, index) => [id, index],
+    ),
+  );
   return {
     schema_version: 1,
     contest: {
@@ -27,12 +59,17 @@ function payload(format, formatConfig, problems, contestants, frozen = false) {
       name: `${format} Resolver Fixture`,
       format,
       format_config: formatConfig,
+      rank_display_options: 3,
       points_precision: 3,
       frozen_last_minutes: frozen ? 60 : 0,
       official_freeze_available: frozen,
     },
     problems,
-    contestants,
+    contestants: contestants.map((entry) => ({
+      ...entry,
+      final_order: finalOrderMap.get(entry.participation_id),
+      frozen_order: frozenOrderMap.get(entry.participation_id),
+    })),
   };
 }
 
@@ -77,45 +114,52 @@ function vnojCell(
   };
 }
 
-const defaultProblems = [problem(101, "alpha", "1", 7), problem(305, "beta", "2", 20)];
+const defaultProblems = [problem(101, "alpha", "1", 7, 100, 11, 2), problem(305, "beta", "2", 20)];
 
-export const defaultPayload = payload("default", {}, defaultProblems, [
-  contestant(
-    11,
-    "alpha",
-    { score: 150, cumtime: 300, tiebreaker: 0 },
-    {
-      101: defaultCell(101, 100, 100),
-      305: defaultCell(305, 50, 200),
-    },
-    null,
-    10,
-  ),
-  contestant(
-    22,
-    "bravo",
-    { score: 150, cumtime: 300, tiebreaker: 0 },
-    {
-      101: defaultCell(101, 100, 180),
-      305: defaultCell(305, 50, 120),
-    },
-    null,
-    99,
-  ),
-  contestant(
-    33,
-    "charlie",
-    { score: 0, cumtime: 0, tiebreaker: 0 },
-    {
-      101: defaultCell(101, 0, 50),
-    },
-  ),
-]);
+export const defaultPayload = payload(
+  "default",
+  {},
+  defaultProblems,
+  [
+    contestant(
+      11,
+      "alpha",
+      { score: 150, cumtime: 300, tiebreaker: 0 },
+      {
+        101: defaultCell(101, 100, 100),
+        305: defaultCell(305, 50, 200),
+      },
+      null,
+      10,
+    ),
+    contestant(
+      22,
+      "bravo",
+      { score: 150, cumtime: 300, tiebreaker: 0 },
+      {
+        101: defaultCell(101, 100, 180),
+        305: defaultCell(305, 50, 120),
+      },
+      null,
+      99,
+    ),
+    contestant(
+      33,
+      "charlie",
+      { score: 0, cumtime: 0, tiebreaker: 0 },
+      {
+        101: defaultCell(101, 0, 50),
+      },
+    ),
+  ],
+  false,
+  [22, 11, 33],
+);
 
 const icpcProblems = [
-  problem(17, "a", "A", 2, 1),
-  problem(42, "b", "B", 9, 1),
-  problem(88, "c", "C", 15, 1),
+  problem(17, "a", "A", 2, 1, 101, 3),
+  problem(42, "b", "B", 9, 1, 303, 2),
+  problem(88, "c", "C", 15, 1, 101, 1),
 ];
 
 export const icpcPayload = payload(
@@ -159,9 +203,11 @@ export const icpcPayload = payload(
     ),
   ],
   true,
+  [303, 202, 101],
+  [303, 202, 101],
 );
 
-const vnojProblems = [problem(9, "x", "1", 4), problem(73, "y", "2", 12)];
+const vnojProblems = [problem(9, "x", "1", 4, 100, 503, 2), problem(73, "y", "2", 12)];
 
 export const vnojPayload = payload(
   "vnoj",
@@ -199,35 +245,53 @@ export const vnojPayload = payload(
     ),
   ],
   true,
+  [503, 501, 502],
+  [503, 502, 501],
 );
 
-export const vnojLsoPayload = payload("vnoj", { penalty: 5, LSO: true }, vnojProblems, [
-  contestant(
-    601,
-    "lso-team",
-    { score: 100, cumtime: 1200, tiebreaker: 300 },
-    {
-      9: vnojCell(9, 50, 100, 1, 0, 0, 0, 0),
-      73: vnojCell(73, 50, 300, 2, 0, 0, 0, 0),
-    },
-  ),
-  contestant(
-    602,
-    "later-team",
-    { score: 100, cumtime: 1250, tiebreaker: 1250 },
-    {
-      9: vnojCell(9, 100, 1250, 0, 0, 0, 0, 0),
-    },
-  ),
-]);
+const vnojLsoProblems = [problem(9, "x", "1", 4, 100, 602, 1), problem(73, "y", "2", 12)];
 
-export const vnojNoPenaltyPayload = payload("vnoj", { penalty: 0, LSO: false }, vnojProblems, [
-  contestant(
-    701,
-    "no-penalty",
-    { score: 100, cumtime: 600, tiebreaker: 600 },
-    {
-      9: vnojCell(9, 100, 600, 7, 0, 0, 0, 0),
-    },
-  ),
-]);
+export const vnojLsoPayload = payload(
+  "vnoj",
+  { penalty: 5, LSO: true },
+  vnojLsoProblems,
+  [
+    contestant(
+      601,
+      "lso-team",
+      { score: 100, cumtime: 1200, tiebreaker: 300 },
+      {
+        9: vnojCell(9, 50, 100, 1, 0, 0, 0, 0),
+        73: vnojCell(73, 50, 300, 2, 0, 0, 0, 0),
+      },
+    ),
+    contestant(
+      602,
+      "later-team",
+      { score: 100, cumtime: 1250, tiebreaker: 1250 },
+      {
+        9: vnojCell(9, 100, 1250, 0, 0, 0, 0, 0),
+      },
+    ),
+  ],
+  false,
+  [601, 602],
+);
+
+const vnojNoPenaltyProblems = [problem(9, "x", "1", 4, 100, 701, 1), problem(73, "y", "2", 12)];
+
+export const vnojNoPenaltyPayload = payload(
+  "vnoj",
+  { penalty: 0, LSO: false },
+  vnojNoPenaltyProblems,
+  [
+    contestant(
+      701,
+      "no-penalty",
+      { score: 100, cumtime: 600, tiebreaker: 600 },
+      {
+        9: vnojCell(9, 100, 600, 7, 0, 0, 0, 0),
+      },
+    ),
+  ],
+);

--- a/resources/resolver/tests/fixtures.js
+++ b/resources/resolver/tests/fixtures.js
@@ -1,0 +1,233 @@
+function problem(id, code, label, order, maxScore = 100) {
+  return { id, code, label, name: `Problem ${label}`, order, max_score: maxScore };
+}
+
+function contestant(id, name, final, problems, frozen = null, submissionCount = 0) {
+  return {
+    participation_id: id,
+    profile_id: id + 1000,
+    username: name,
+    display_name: name.toUpperCase(),
+    avatar_url: null,
+    organization: null,
+    is_disqualified: false,
+    submission_count: submissionCount,
+    final,
+    frozen,
+    problems,
+  };
+}
+
+function payload(format, formatConfig, problems, contestants, frozen = false) {
+  return {
+    schema_version: 1,
+    contest: {
+      id: 1,
+      key: `resolver-${format}`,
+      name: `${format} Resolver Fixture`,
+      format,
+      format_config: formatConfig,
+      points_precision: 3,
+      frozen_last_minutes: frozen ? 60 : 0,
+      official_freeze_available: frozen,
+    },
+    problems,
+    contestants,
+  };
+}
+
+function defaultCell(problemId, points, time) {
+  return {
+    problem_id: problemId,
+    attempted: true,
+    final: { points, time },
+    frozen: null,
+  };
+}
+
+function icpcCell(problemId, points, time, tries, frozenPoints, frozenTries, pending) {
+  return {
+    problem_id: problemId,
+    attempted: true,
+    final: { points, time, tries },
+    frozen: { points: frozenPoints, time, tries: frozenTries, pending },
+  };
+}
+
+function vnojCell(
+  problemId,
+  points,
+  time,
+  penalty,
+  pending,
+  frozenPoints,
+  frozenTime,
+  frozenPenalty,
+) {
+  return {
+    problem_id: problemId,
+    attempted: true,
+    final: { points, time, penalty, pending },
+    frozen: {
+      points: frozenPoints,
+      time: frozenTime,
+      penalty: frozenPenalty,
+      pending,
+    },
+  };
+}
+
+const defaultProblems = [problem(101, "alpha", "1", 7), problem(305, "beta", "2", 20)];
+
+export const defaultPayload = payload("default", {}, defaultProblems, [
+  contestant(
+    11,
+    "alpha",
+    { score: 150, cumtime: 300, tiebreaker: 0 },
+    {
+      101: defaultCell(101, 100, 100),
+      305: defaultCell(305, 50, 200),
+    },
+    null,
+    10,
+  ),
+  contestant(
+    22,
+    "bravo",
+    { score: 150, cumtime: 300, tiebreaker: 0 },
+    {
+      101: defaultCell(101, 100, 180),
+      305: defaultCell(305, 50, 120),
+    },
+    null,
+    99,
+  ),
+  contestant(
+    33,
+    "charlie",
+    { score: 0, cumtime: 0, tiebreaker: 0 },
+    {
+      101: defaultCell(101, 0, 50),
+    },
+  ),
+]);
+
+const icpcProblems = [
+  problem(17, "a", "A", 2, 1),
+  problem(42, "b", "B", 9, 1),
+  problem(88, "c", "C", 15, 1),
+];
+
+export const icpcPayload = payload(
+  "icpc",
+  { penalty: 15 },
+  icpcProblems,
+  [
+    contestant(
+      101,
+      "pending-team",
+      { score: 2, cumtime: 85, tiebreaker: 60 },
+      {
+        17: icpcCell(17, 1, 600, 1, 1, 1, false),
+        42: icpcCell(42, 0, 2400, 3, 0, 2, true),
+        88: icpcCell(88, 1, 3600, 2, 0, 2, true),
+      },
+      { score: 1, cumtime: 10, tiebreaker: 10 },
+      12,
+    ),
+    contestant(
+      202,
+      "steady-team",
+      { score: 2, cumtime: 85, tiebreaker: 50 },
+      {
+        17: icpcCell(17, 1, 1200, 2, 1, 2, false),
+        42: icpcCell(42, 1, 3000, 1, 1, 1, false),
+      },
+      { score: 2, cumtime: 85, tiebreaker: 50 },
+      2,
+    ),
+    contestant(
+      303,
+      "tied-team",
+      { score: 2, cumtime: 85, tiebreaker: 50 },
+      {
+        17: icpcCell(17, 1, 1200, 1, 1, 1, false),
+        42: icpcCell(42, 1, 3000, 2, 1, 2, false),
+      },
+      { score: 2, cumtime: 85, tiebreaker: 50 },
+      200,
+    ),
+  ],
+  true,
+);
+
+const vnojProblems = [problem(9, "x", "1", 4), problem(73, "y", "2", 12)];
+
+export const vnojPayload = payload(
+  "vnoj",
+  { penalty: 5, LSO: false },
+  vnojProblems,
+  [
+    contestant(
+      501,
+      "improving",
+      { score: 100, cumtime: 1200, tiebreaker: 600 },
+      {
+        9: vnojCell(9, 100, 600, 2, 2, 50, 300, 1),
+        73: vnojCell(73, 0, 400, 3, 0, 0, 400, 3),
+      },
+      { score: 50, cumtime: 600, tiebreaker: 300 },
+    ),
+    contestant(
+      502,
+      "partials",
+      { score: 100, cumtime: 1300, tiebreaker: 900 },
+      {
+        9: vnojCell(9, 50, 900, 0, 0, 50, 900, 0),
+        73: vnojCell(73, 50, 100, 1, 0, 50, 100, 1),
+      },
+      { score: 100, cumtime: 1300, tiebreaker: 900 },
+    ),
+    contestant(
+      503,
+      "already-full",
+      { score: 100, cumtime: 200, tiebreaker: 200 },
+      {
+        9: vnojCell(9, 100, 200, 0, 1, 100, 200, 0),
+      },
+      { score: 100, cumtime: 200, tiebreaker: 200 },
+    ),
+  ],
+  true,
+);
+
+export const vnojLsoPayload = payload("vnoj", { penalty: 5, LSO: true }, vnojProblems, [
+  contestant(
+    601,
+    "lso-team",
+    { score: 100, cumtime: 1200, tiebreaker: 300 },
+    {
+      9: vnojCell(9, 50, 100, 1, 0, 0, 0, 0),
+      73: vnojCell(73, 50, 300, 2, 0, 0, 0, 0),
+    },
+  ),
+  contestant(
+    602,
+    "later-team",
+    { score: 100, cumtime: 1250, tiebreaker: 1250 },
+    {
+      9: vnojCell(9, 100, 1250, 0, 0, 0, 0, 0),
+    },
+  ),
+]);
+
+export const vnojNoPenaltyPayload = payload("vnoj", { penalty: 0, LSO: false }, vnojProblems, [
+  contestant(
+    701,
+    "no-penalty",
+    { score: 100, cumtime: 600, tiebreaker: 600 },
+    {
+      9: vnojCell(9, 100, 600, 7, 0, 0, 0, 0),
+    },
+  ),
+]);

--- a/resources/resolver/tests/planner-player.test.js
+++ b/resources/resolver/tests/planner-player.test.js
@@ -1,0 +1,429 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ResolverSession } from "../core.js";
+import { ResolutionPlanner } from "../planner.js";
+import { ResolutionPlayer } from "../player.js";
+import { RowSweepPolicy, selectRowSweepTarget } from "../policies.js";
+import {
+  ICPC_EVENT_DELAYS_MS,
+  RESOLUTION_STEP_TYPES,
+  effectiveDelay,
+  usesSingleStepTiming,
+} from "../timing.js";
+import { icpcPayload } from "./fixtures.js";
+import { defaultPayload } from "./fixtures.js";
+
+function problem(id, order) {
+  return {
+    id,
+    code: id,
+    label: id,
+    name: `Problem ${id}`,
+    order,
+    max_score: 1,
+    first_solve_participation_id: null,
+    final_total_ac: 0,
+  };
+}
+
+function icpcCell(problemId, points, time, tries, frozenPoints, frozenTries, pending) {
+  return {
+    problem_id: problemId,
+    attempted: true,
+    final: { points, time, tries },
+    frozen: { points: frozenPoints, time, tries: frozenTries, pending },
+  };
+}
+
+function contestant(id, problems, order) {
+  return {
+    participation_id: id,
+    profile_id: id + 100,
+    username: `team-${id}`,
+    display_name: `Team ${id}`,
+    full_name: "",
+    user_css_class: "rating rate-none user",
+    profile_url: `/user/team-${id}`,
+    avatar_url: null,
+    rank_logo_url: null,
+    organizations: [],
+    is_disqualified: false,
+    submission_count: 0,
+    final_order: order,
+    frozen_order: order,
+    final: { score: 0, cumtime: 0, tiebreaker: 0 },
+    frozen: { score: 0, cumtime: 0, tiebreaker: 0 },
+    problems,
+  };
+}
+
+function rowSweepPayload() {
+  const problems = [problem("A", 0), problem("B", 1), problem("C", 2), problem("D", 3)];
+  const contestants = [];
+  for (let id = 1; id <= 4; id += 1) {
+    contestants.push(
+      contestant(
+        id,
+        {
+          A: icpcCell("A", 1, id * 60, 1, 1, 1, false),
+          B: icpcCell("B", 1, (id + 4) * 60, 1, 1, 1, false),
+        },
+        id - 1,
+      ),
+    );
+  }
+  for (let id = 5; id <= 9; id += 1) {
+    const cells = {
+      A: icpcCell("A", 1, (id - 4) * 600, 1, 1, 1, false),
+    };
+    if (id === 9) {
+      cells.D = icpcCell("D", 0, 3600, 1, 0, 1, true);
+    }
+    contestants.push(contestant(id, cells, id - 1));
+  }
+  contestants.push(
+    contestant(
+      10,
+      {
+        B: icpcCell("B", 1, 300, 1, 0, 1, true),
+        C: icpcCell("C", 1, 420, 1, 0, 1, true),
+      },
+      9,
+    ),
+  );
+  return {
+    schema_version: 1,
+    contest: {
+      id: 9,
+      key: "row-sweep",
+      name: "Row sweep",
+      format: "icpc",
+      format_config: { penalty: 20 },
+      rank_display_options: 3,
+      points_precision: 3,
+      frozen_last_minutes: 60,
+      official_freeze_available: true,
+    },
+    problems,
+    contestants,
+  };
+}
+
+function sameRowPayload() {
+  const problems = [
+    { ...problem("A", 0), max_score: 100 },
+    { ...problem("B", 1), max_score: 100 },
+  ];
+  const defaultCell = (problemId, points, time) => ({
+    problem_id: problemId,
+    attempted: true,
+    final: { points, time },
+    frozen: null,
+  });
+  const contestants = [1, 2, 3].map((id, index) => ({
+    ...contestant(
+      id,
+      id === 3 ? { A: defaultCell("A", 0, 30), B: defaultCell("B", 100, 60) } : {},
+      index,
+    ),
+    final:
+      id === 3
+        ? { score: 100, cumtime: 60, tiebreaker: 0 }
+        : { score: 0, cumtime: 0, tiebreaker: 0 },
+    frozen: null,
+  }));
+  return {
+    schema_version: 1,
+    contest: {
+      id: 10,
+      key: "same-row",
+      name: "Same row",
+      format: "default",
+      format_config: {},
+      rank_display_options: 3,
+      points_precision: 3,
+      frozen_last_minutes: 0,
+      official_freeze_available: false,
+    },
+    problems,
+    contestants,
+  };
+}
+
+function createPlayer({ speed = 1, waits = [], steps = [], wait = null } = {}) {
+  const session = new ResolverSession(icpcPayload, {
+    baseline: "official-freeze",
+    tieOrder: "seeded",
+  });
+  const policy = new RowSweepPolicy(icpcPayload.problems.map((entry) => entry.id));
+  const planner = new ResolutionPlanner({
+    payload: icpcPayload,
+    targetSelector: (currentSession) => policy.select(currentSession),
+    singleStepStartRank: 1,
+    awardPlaces: 0,
+    hardPauses: { singleStep: true, award: false, firstSolve: true },
+  });
+  const player = new ResolutionPlayer({
+    session,
+    planner,
+    playbackSpeed: speed,
+    wait: wait ?? (async (duration) => waits.push(duration)),
+    onStep: async (step) => steps.push(step.type),
+  });
+  return { session, player };
+}
+
+test("ICPC row sweep stays on row 10 after its occupant moves from #10 to #5", () => {
+  const payload = rowSweepPayload();
+  const session = new ResolverSession(payload, {
+    baseline: "official-freeze",
+    tieOrder: "seeded",
+  });
+  const policy = new RowSweepPolicy(payload.problems.map((entry) => entry.id));
+
+  const first = policy.select(session);
+  assert.deepEqual(first, { contestantId: 10, problemId: "B" });
+  const transition = session.revealCell(first.contestantId, first.problemId);
+  assert.equal(transition.effects.positionBefore, 10);
+  assert.equal(transition.effects.positionAfter, 5);
+
+  const second = policy.select(session);
+  assert.deepEqual(second, { contestantId: 9, problemId: "D" });
+  assert.notEqual(second.contestantId, 10);
+  assert.equal(
+    session.getState().standings.at(-1).contestantId,
+    9,
+    "the new row-10 occupant is selected immediately",
+  );
+});
+
+test("same-row result keeps the contestant eligible for its next leftmost cell", () => {
+  const payload = sameRowPayload();
+  const session = new ResolverSession(payload, { baseline: "beginning", tieOrder: "source" });
+  const policy = new RowSweepPolicy(payload.problems.map((entry) => entry.id));
+  const first = policy.select(session);
+  assert.deepEqual(first, { contestantId: 3, problemId: "A" });
+  const transition = session.revealCell(first.contestantId, first.problemId);
+  assert.equal(transition.effects.positionAfter, transition.effects.positionBefore);
+  assert.deepEqual(policy.select(session), { contestantId: 3, problemId: "B" });
+});
+
+test("row-sweep selection is bottom-most first and leftmost within that contestant", () => {
+  const standings = [{ contestantId: 1 }, { contestantId: 2 }, { contestantId: 3 }];
+  const cells = [
+    { contestantId: 1, problemId: "A" },
+    { contestantId: 3, problemId: "C" },
+    { contestantId: 3, problemId: "B" },
+  ];
+  assert.deepEqual(selectRowSweepTarget(standings, cells, ["A", "B", "C"]), {
+    contestantId: 3,
+    problemId: "B",
+  });
+});
+
+test("predetermined choice only overrides problem order inside the lowest contestant", () => {
+  const standings = [{ contestantId: 1 }, { contestantId: 2 }, { contestantId: 3 }];
+  const cells = [
+    { contestantId: 1, problemId: "C" },
+    { contestantId: 3, problemId: "A" },
+    { contestantId: 3, problemId: "B" },
+  ];
+  assert.deepEqual(selectRowSweepTarget(standings, cells, ["A", "B", "C"], { 1: "C", 3: "B" }), {
+    contestantId: 3,
+    problemId: "B",
+  });
+  assert.deepEqual(selectRowSweepTarget(standings, cells, ["A", "B", "C"], { 3: "missing" }), {
+    contestantId: 3,
+    problemId: "A",
+  });
+});
+
+test("official ICPC event delays and playback speed scaling are exact", () => {
+  assert.deepEqual(ICPC_EVENT_DELAYS_MS, {
+    SELECT_TEAM: 1300,
+    SELECT_PROBLEM: 1000,
+    RESULT_MOVE: 2250,
+    RESULT_STAY: 1500,
+    RESULT_FAILED: 850,
+    DESELECT: 250,
+    SELECT_SUBMISSION: 450,
+  });
+  assert.equal(effectiveDelay(2250, 2), 1125);
+  assert.equal(effectiveDelay(2250, 0.5), 4500);
+});
+
+test("singleStepStartRank is one-based: rank 7 auto, rank 6 single-step", () => {
+  assert.equal(usesSingleStepTiming(7, 6), false);
+  assert.equal(usesSingleStepTiming(6, 6), true);
+});
+
+test("SingleStepTiming pauses after team, problem, and result but not deselection", () => {
+  const session = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    tieOrder: "source",
+  });
+  const policy = new RowSweepPolicy(defaultPayload.problems.map((entry) => entry.id));
+  const planner = new ResolutionPlanner({
+    payload: defaultPayload,
+    targetSelector: (currentSession) => policy.select(currentSession),
+    singleStepStartRank: 1,
+    awardPlaces: 0,
+  });
+  const plan = planner.planNext(session);
+  assert.equal(plan.timing, "single-step");
+  assert.deepEqual(
+    plan.steps.filter((step) => step.type === RESOLUTION_STEP_TYPES.PAUSE).map((step) => step.kind),
+    ["single-step-team", "single-step-problem", "single-step-result"],
+  );
+  const deselectIndex = plan.steps.findIndex(
+    (step) => step.type === RESOLUTION_STEP_TYPES.DESELECT,
+  );
+  assert.equal(
+    plan.steps.slice(deselectIndex + 1).some((step) => step.type === RESOLUTION_STEP_TYPES.PAUSE),
+    false,
+  );
+});
+
+test("Rewind clears a selection-only SingleStep pause before any reveal", async () => {
+  const session = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    tieOrder: "source",
+  });
+  const policy = new RowSweepPolicy(defaultPayload.problems.map((entry) => entry.id));
+  const planner = new ResolutionPlanner({
+    payload: defaultPayload,
+    targetSelector: (currentSession) => policy.select(currentSession),
+    singleStepStartRank: 1,
+    awardPlaces: 0,
+  });
+  const player = new ResolutionPlayer({ session, planner });
+
+  const result = await player.fastForwardToNextPause();
+  assert.equal(result.pause.kind, "single-step-team");
+  assert.equal(session.getHistory().cursor, 0);
+  assert.notEqual(player.getState().presentation.selectedContestantId, null);
+
+  await player.rewindToPreviousPause();
+  assert.deepEqual(player.getState().presentation, {
+    selectedContestantId: null,
+    selectedProblemId: null,
+    resultType: null,
+  });
+  assert.equal(player.getState().checkpointIndex, 0);
+  assert.equal(session.getHistory().cursor, 0);
+});
+
+test("Forward executes intermediate actions and delays until the next hard PauseStep", async () => {
+  const waits = [];
+  const steps = [];
+  const { session, player } = createPlayer({ waits, steps });
+  const result = await player.playToNextPause(true);
+
+  assert.equal(result.pause.type, RESOLUTION_STEP_TYPES.PAUSE);
+  assert.equal(result.pause.kind, "first-solve");
+  assert.equal(session.getHistory().cursor, 2);
+  assert.deepEqual(waits, [1300, 1000, 850, 250, 1300, 1000, 1500]);
+  assert.equal(steps.includes(RESOLUTION_STEP_TYPES.SELECT_TEAM), true);
+  assert.equal(steps.includes(RESOLUTION_STEP_TYPES.SELECT_PROBLEM), true);
+  assert.equal(steps.filter((type) => type === RESOLUTION_STEP_TYPES.REVEAL_CELL).length, 2);
+});
+
+test("Fast Forward reaches the same semantic pause state without narrative delays", async () => {
+  const forward = createPlayer();
+  await forward.player.playToNextPause(true);
+  const expected = forward.session.getState();
+
+  const waits = [];
+  const fast = createPlayer({ waits });
+  const result = await fast.player.fastForwardToNextPause();
+  assert.equal(result.pause.kind, "first-solve");
+  assert.deepEqual(fast.session.getState(), expected);
+  assert.deepEqual(waits, []);
+});
+
+test("Rewind restores the exact previous semantic pause state", async () => {
+  const { session, player } = createPlayer();
+  const baseline = session.getState();
+  await player.fastForwardToNextPause();
+  assert.equal(session.getHistory().cursor, 2);
+  await player.rewindToPreviousPause();
+  assert.deepEqual(session.getState(), baseline);
+  assert.equal(session.getHistory().cursor, 0);
+});
+
+test("Reset and replay are deterministic", async () => {
+  const { session, player } = createPlayer();
+  const baseline = session.getState();
+  await player.fastForwardToNextPause();
+  const firstRun = session.getState();
+  await player.resetToBeginning();
+  assert.deepEqual(session.getState(), baseline);
+  await player.fastForwardToNextPause();
+  assert.deepEqual(session.getState(), firstRun);
+});
+
+test("row-sweep selection remains pure when called repeatedly during render", () => {
+  const session = new ResolverSession(icpcPayload, { baseline: "official-freeze" });
+  const policy = new RowSweepPolicy(icpcPayload.problems.map((entry) => entry.id));
+  const historyBefore = session.getHistory();
+  const first = policy.select(session);
+  const second = policy.select(session);
+  assert.deepEqual(second, first);
+  assert.deepEqual(session.getHistory(), historyBefore);
+});
+
+test("operator projection simulates the next reveal without mutating live state", () => {
+  const payload = rowSweepPayload();
+  const session = new ResolverSession(payload, {
+    baseline: "official-freeze",
+    tieOrder: "seeded",
+  });
+  const policy = new RowSweepPolicy(payload.problems.map((entry) => entry.id));
+  const planner = new ResolutionPlanner({
+    payload,
+    targetSelector: (currentSession) => policy.select(currentSession),
+    singleStepStartRank: 6,
+    awardPlaces: 6,
+  });
+  const stateBefore = session.getState();
+  const historyBefore = session.getHistory();
+  const projection = planner.projectNext(session);
+  assert.deepEqual(
+    {
+      currentPosition: projection.currentPosition,
+      actualPositionAfterReveal: projection.actualPositionAfterReveal,
+      movementDelta: projection.movementDelta,
+      remainingUnresolvedCells: projection.remainingUnresolvedCells,
+    },
+    {
+      currentPosition: 10,
+      actualPositionAfterReveal: 5,
+      movementDelta: 5,
+      remainingUnresolvedCells: 2,
+    },
+  );
+  assert.deepEqual(session.getState(), stateBefore);
+  assert.deepEqual(session.getHistory(), historyBefore);
+});
+
+test("cancelling playback prevents overlapping asynchronous reveal chains", async () => {
+  let releaseDelay;
+  let signalDelayStarted;
+  const delayStarted = new Promise((resolve) => {
+    signalDelayStarted = resolve;
+  });
+  const wait = () =>
+    new Promise((resolve) => {
+      releaseDelay = resolve;
+      signalDelayStarted();
+    });
+  const { session, player } = createPlayer({ wait });
+  const run = player.playToNextPause(true);
+  await delayStarted;
+  player.cancel("Operator pause.");
+  releaseDelay();
+  await run;
+  assert.equal(session.getHistory().cursor, 0);
+  assert.equal(player.getState().running, false);
+});

--- a/resources/resolver/tests/resolver.test.js
+++ b/resources/resolver/tests/resolver.test.js
@@ -1,0 +1,513 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ResolverSession,
+  UnsupportedResolverBaselineError,
+  UnsupportedResolverFormatError,
+} from "../core.js";
+import {
+  AutoplayController,
+  CEREMONY_PRESETS,
+  SPEED_PRESETS,
+  getPauseReason,
+  normalizeAwardPlaces,
+} from "../controller.js";
+import { rankContestants } from "../ranking.js";
+import {
+  BottomUpStickyPolicy,
+  ByContestantPolicy,
+  ByProblemPolicy,
+  selectBottomUpStickyTarget,
+  selectByContestantTarget,
+  selectByProblemTarget,
+} from "../policies.js";
+import { deriveProblemStats, getCellPresentation } from "../presentation.js";
+import { roundLikePython } from "../utils.js";
+import {
+  defaultPayload,
+  icpcPayload,
+  vnojLsoPayload,
+  vnojNoPenaltyPayload,
+  vnojPayload,
+} from "./fixtures.js";
+
+function getContestant(session, contestantId) {
+  return session
+    .getState()
+    .contestants.find((contestant) => String(contestant.participationId) === String(contestantId));
+}
+
+function revealAll(session) {
+  while (session.getResolvableCells().length) {
+    const target = session.getResolvableCells()[0];
+    session.revealCell(target.contestantId, target.problemId);
+  }
+}
+
+function assertFinalParity(session, payload, expectedRanks, expectedOrder) {
+  revealAll(session);
+  const state = session.getState();
+
+  payload.contestants.forEach((sourceContestant) => {
+    const actual = state.contestants.find(
+      (contestant) => contestant.participationId === sourceContestant.participation_id,
+    );
+    assert.deepEqual(
+      {
+        score: actual.score,
+        cumtime: actual.cumtime,
+        tiebreaker: actual.tiebreaker,
+      },
+      sourceContestant.final,
+    );
+  });
+
+  Object.entries(expectedRanks).forEach(([contestantId, expectedRank]) => {
+    const standing = state.standings.find(
+      (entry) => String(entry.contestantId) === String(contestantId),
+    );
+    assert.equal(standing.rank, expectedRank);
+  });
+
+  if (expectedOrder) {
+    assert.deepEqual(
+      state.standings.map((standing) => standing.contestantId),
+      expectedOrder,
+    );
+  }
+}
+
+test("Default beginning baseline handles partial and zero scores without problem indexes", () => {
+  const session = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    seed: "default-seed",
+  });
+  const initial = session.getState();
+  assert.equal(
+    initial.standings.every((standing) => standing.rank === 1),
+    true,
+  );
+  assert.equal(session.getResolvableCells().length, 5);
+
+  session.revealCell(11, 101);
+  let contestant = getContestant(session, 11);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 100, cumtime: 100, tiebreaker: 0 },
+  );
+
+  session.revealCell(33, 101);
+  contestant = getContestant(session, 33);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime },
+    { score: 0, cumtime: 0 },
+  );
+
+  assertFinalParity(session, defaultPayload, { 11: 1, 22: 1, 33: 3 });
+  const tied = session.getState().standings.filter((standing) => standing.rank === 1);
+  assert.equal(tied.length, 2);
+});
+
+test("ICPC official freeze preserves minutes, configured penalty, pending failures, and tied ranks", () => {
+  const session = new ResolverSession(icpcPayload, {
+    baseline: "official-freeze",
+    seed: "icpc-seed",
+  });
+  assert.deepEqual(session.getResolvableCells(), [
+    { contestantId: 101, problemId: 42 },
+    { contestantId: 101, problemId: 88 },
+  ]);
+
+  let contestant = getContestant(session, 101);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 1, cumtime: 10, tiebreaker: 10 },
+  );
+
+  session.revealCell(101, 42);
+  contestant = getContestant(session, 101);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 1, cumtime: 10, tiebreaker: 10 },
+  );
+
+  session.revealCell(101, 88);
+  contestant = getContestant(session, 101);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 2, cumtime: 85, tiebreaker: 60 },
+  );
+
+  assertFinalParity(session, icpcPayload, { 101: 3, 202: 1, 303: 1 });
+  const order = session.getState().standings.map((standing) => standing.contestantId);
+  assert.equal(order.indexOf(202) < order.indexOf(101), true);
+  assert.equal(order.indexOf(303) < order.indexOf(101), true);
+});
+
+test("ICPC beginning baseline scores an AC after wrong tries independently of freeze", () => {
+  const session = new ResolverSession(icpcPayload, { baseline: "beginning", seed: "icpc-full" });
+  session.revealCell(101, 88);
+  const contestant = getContestant(session, 101);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 1, cumtime: 75, tiebreaker: 60 },
+  );
+});
+
+test("VNOJ official freeze uses pending counts and excludes zero-score penalties", () => {
+  const session = new ResolverSession(vnojPayload, {
+    baseline: "official-freeze",
+    seed: "vnoj-seed",
+  });
+  assert.deepEqual(session.getResolvableCells(), [{ contestantId: 501, problemId: 9 }]);
+
+  let contestant = getContestant(session, 501);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 50, cumtime: 600, tiebreaker: 300 },
+  );
+
+  const alreadyFull = getContestant(session, 503);
+  assert.equal(alreadyFull.problems["9"].revealed, true);
+  assert.equal(alreadyFull.problems["9"].pending, 0);
+
+  session.revealCell(501, 9);
+  contestant = getContestant(session, 501);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 100, cumtime: 1200, tiebreaker: 600 },
+  );
+  assertFinalParity(session, vnojPayload, { 501: 2, 502: 3, 503: 1 }, [503, 501, 502]);
+});
+
+test("VNOJ LSO true uses maximum score-altering time plus aggregate penalty", () => {
+  const session = new ResolverSession(vnojLsoPayload, { baseline: "beginning", seed: "lso" });
+  session.revealCell(601, 9);
+  let contestant = getContestant(session, 601);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 50, cumtime: 400, tiebreaker: 100 },
+  );
+  session.revealCell(601, 73);
+  contestant = getContestant(session, 601);
+  assert.deepEqual(
+    { score: contestant.score, cumtime: contestant.cumtime, tiebreaker: contestant.tiebreaker },
+    { score: 100, cumtime: 1200, tiebreaker: 300 },
+  );
+  assertFinalParity(session, vnojLsoPayload, { 601: 1, 602: 2 }, [601, 602]);
+});
+
+test("VNOJ penalty zero ignores stored cell penalty counts", () => {
+  const session = new ResolverSession(vnojNoPenaltyPayload, { baseline: "beginning" });
+  assertFinalParity(session, vnojNoPenaltyPayload, { 701: 1 }, [701]);
+});
+
+test("ranking uses tie-aware displayed ranks and deterministic fallback, not submission count", () => {
+  const ranked = rankContestants([
+    { participationId: 1, isDisqualified: false, score: 10, cumtime: 20, tiebreaker: 5, tieKey: 9 },
+    { participationId: 2, isDisqualified: false, score: 10, cumtime: 20, tiebreaker: 5, tieKey: 1 },
+    { participationId: 3, isDisqualified: false, score: 9, cumtime: 1, tiebreaker: 1, tieKey: 0 },
+    { participationId: 4, isDisqualified: true, score: 100, cumtime: 0, tiebreaker: 0, tieKey: 0 },
+  ]);
+  assert.deepEqual(
+    ranked.map((entry) => entry.contestantId),
+    [2, 1, 3, 4],
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.rank),
+    [1, 1, 3, 4],
+  );
+});
+
+test("history restores exact states, supports forward, invalidates redo, and resets deterministically", () => {
+  const session = new ResolverSession(defaultPayload, { baseline: "beginning", seed: "history" });
+  const state0 = session.getState();
+  const transitionA = session.revealCell(11, 101);
+  const transitionB = session.revealCell(11, 305);
+  session.revealCell(22, 101);
+
+  assert.equal(session.back(), true);
+  assert.deepEqual(session.getState(), transitionB.after);
+  assert.equal(session.back(), true);
+  assert.deepEqual(session.getState(), transitionA.after);
+  assert.equal(session.forward(), true);
+  assert.deepEqual(session.getState(), transitionB.after);
+
+  session.revealCell(22, 305);
+  assert.equal(session.forward(), false);
+  const history = session.getHistory();
+  assert.equal(history.cursor, 3);
+  assert.deepEqual(
+    history.transitions.map((item) => item.target),
+    [
+      { contestantId: 11, problemId: 101 },
+      { contestantId: 11, problemId: 305 },
+      { contestantId: 22, problemId: 305 },
+    ],
+  );
+
+  assert.deepEqual(session.reset(), state0);
+  assert.deepEqual(session.replay(), state0);
+  const secondSession = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    seed: "history",
+  });
+  assert.deepEqual(secondSession.getState(), state0);
+});
+
+test("source payload is immutable and resolver operations do not mutate caller data", () => {
+  const callerPayload = structuredClone(defaultPayload);
+  const before = structuredClone(callerPayload);
+  const session = new ResolverSession(callerPayload, { baseline: "beginning" });
+  assert.equal(Object.isFrozen(session.source), true);
+  assert.equal(Object.isFrozen(session.source.contestants[0].problems["101"].final), true);
+  session.revealCell(11, 101);
+  assert.deepEqual(callerPayload, before);
+  assert.deepEqual(session.source, before);
+});
+
+test("a fully resolved disqualified contestant matches the stored final override", () => {
+  const payload = structuredClone(defaultPayload);
+  payload.contestants[0].is_disqualified = true;
+  payload.contestants[0].final = { score: -9999, cumtime: 0, tiebreaker: 0 };
+  const session = new ResolverSession(payload, { baseline: "beginning", seed: "dq" });
+
+  assertFinalParity(session, payload, { 11: 3, 22: 1, 33: 2 }, [22, 33, 11]);
+});
+
+test("unsupported formats and unavailable official freezes reject clearly", () => {
+  const unsupported = structuredClone(defaultPayload);
+  unsupported.contest.format = "atcoder";
+  assert.throws(() => new ResolverSession(unsupported), UnsupportedResolverFormatError);
+  assert.throws(
+    () => new ResolverSession(defaultPayload, { baseline: "official-freeze" }),
+    UnsupportedResolverBaselineError,
+  );
+});
+
+test("score rounding uses Python-compatible half-even behavior for exact halves", () => {
+  assert.equal(roundLikePython(2.5), 2);
+  assert.equal(roundLikePython(3.5), 4);
+  assert.equal(roundLikePython(-2.5), -2);
+  assert.equal(roundLikePython(1.225, 2), 1.23);
+  assert.equal(roundLikePython(2.675, 2), 2.67);
+});
+
+test("bottom-up sticky policy selects the current lowest unresolved contestant and stays sticky", () => {
+  const standings = [
+    { contestantId: 1, position: 1 },
+    { contestantId: 2, position: 2 },
+    { contestantId: 3, position: 3 },
+  ];
+  const cells = [
+    { contestantId: 1, problemId: "A" },
+    { contestantId: 2, problemId: "A" },
+    { contestantId: 2, problemId: "B" },
+  ];
+  assert.deepEqual(selectBottomUpStickyTarget(standings, cells), {
+    contestantId: 2,
+    problemId: "A",
+  });
+  assert.deepEqual(selectBottomUpStickyTarget(standings, cells, 1), {
+    contestantId: 1,
+    problemId: "A",
+  });
+  assert.equal(selectBottomUpStickyTarget(standings, [], 1), null);
+
+  const session = new ResolverSession(defaultPayload, { baseline: "beginning", seed: "policy" });
+  const policy = new BottomUpStickyPolicy();
+  const first = policy.select(session);
+  session.revealCell(first.contestantId, first.problemId);
+  const remainingForSticky = session
+    .getResolvableCells()
+    .filter((cell) => String(cell.contestantId) === String(first.contestantId));
+  const second = policy.select(session);
+  if (remainingForSticky.length) {
+    assert.equal(String(second.contestantId), String(first.contestantId));
+  }
+});
+
+test("derived Total AC and first solve only use the current revealed state", () => {
+  const session = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    seed: "presentation",
+  });
+  let stats = deriveProblemStats(defaultPayload, session.getState());
+  assert.deepEqual(
+    stats.map((stat) => [stat.problemId, stat.totalSolved, stat.firstSolveContestantId]),
+    [
+      [101, 0, null],
+      [305, 0, null],
+    ],
+  );
+
+  session.revealCell(22, 101);
+  stats = deriveProblemStats(defaultPayload, session.getState());
+  assert.deepEqual(
+    [stats[0].totalSolved, stats[0].firstSolveContestantId, stats[0].firstSolveTime],
+    [1, 22, 180],
+  );
+  session.revealCell(11, 101);
+  stats = deriveProblemStats(defaultPayload, session.getState());
+  assert.deepEqual(
+    [stats[0].totalSolved, stats[0].firstSolveContestantId, stats[0].firstSolveTime],
+    [2, 11, 100],
+  );
+});
+
+test("frozen ICPC presentation hides final solve time until reveal", () => {
+  const session = new ResolverSession(icpcPayload, {
+    baseline: "official-freeze",
+    seed: "presentation-freeze",
+  });
+  const contestant = getContestant(session, 101);
+  const pending = getCellPresentation("icpc", contestant.problems["88"], 3);
+  assert.equal(pending.primary, "2 tries");
+  assert.equal(pending.secondary, "Pending");
+  assert.equal(pending.accessibleLabel.includes("60"), false);
+
+  session.revealCell(101, 88);
+  const revealed = getCellPresentation("icpc", getContestant(session, 101).problems["88"], 3);
+  assert.equal(revealed.primary, "60");
+  assert.equal(revealed.secondary, "2 tries");
+});
+
+test("Phase 3 presets are deterministic and Director never starts an automatic policy", () => {
+  assert.deepEqual(
+    {
+      baseline: CEREMONY_PRESETS.icpc.baseline,
+      policy: CEREMONY_PRESETS.icpc.policy,
+      tieOrder: CEREMONY_PRESETS.icpc.tieOrder,
+    },
+    { baseline: "auto", policy: "bottom-up-sticky", tieOrder: "seeded" },
+  );
+  assert.equal(CEREMONY_PRESETS.full.baseline, "beginning");
+  assert.equal(CEREMONY_PRESETS.director.policy, "manual");
+  assert.equal(SPEED_PRESETS.length, 4);
+  assert.equal(normalizeAwardPlaces(20, 8), 8);
+  assert.equal(normalizeAwardPlaces(0, 8), 0);
+});
+
+test("source tie order is explicit while seeded Replay restores the exact baseline", () => {
+  const sourceSession = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    tieOrder: "source",
+  });
+  assert.deepEqual(
+    sourceSession.getState().standings.map((standing) => standing.contestantId),
+    defaultPayload.contestants.map((contestant) => contestant.participation_id),
+  );
+
+  const seeded = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    tieOrder: "seeded",
+    seed: "phase-3-replay",
+  });
+  const baseline = seeded.getState();
+  seeded.revealCell(11, 101);
+  assert.deepEqual(seeded.replay(), baseline);
+});
+
+test("semantic transition effects detect first solve and ceremony pause beats", () => {
+  const session = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    seed: "phase-3-effects",
+  });
+  const first = session.revealCell(11, 101);
+  const later = session.revealCell(22, 101);
+  assert.equal(first.effects.firstSolveAppeared, true);
+  assert.equal(later.effects.firstSolveAppeared, false);
+
+  assert.equal(
+    getPauseReason(
+      [
+        {
+          effects: {
+            rankBefore: 5,
+            rankAfter: 3,
+            contestantFinished: false,
+            firstSolveAppeared: false,
+          },
+        },
+      ],
+      { rankChange: true, awardZone: true, contestantFinished: true, firstSolve: true },
+      3,
+    ),
+    "Entered the top 3 award zone.",
+  );
+});
+
+test("by-problem and by-contestant policies choose semantic IDs without table columns", () => {
+  const standings = [{ contestantId: 1 }, { contestantId: 2 }, { contestantId: 3 }];
+  const cells = [
+    { contestantId: 1, problemId: "B" },
+    { contestantId: 2, problemId: "A" },
+    { contestantId: 3, problemId: "A" },
+  ];
+  assert.deepEqual(selectByProblemTarget(standings, cells, ["A", "B"]), {
+    contestantId: 3,
+    problemId: "A",
+  });
+  assert.deepEqual(selectByProblemTarget(standings, cells, ["A", "B"], "B"), {
+    contestantId: 1,
+    problemId: "B",
+  });
+  assert.deepEqual(selectByContestantTarget(standings, cells), {
+    contestantId: 1,
+    problemId: "B",
+  });
+
+  const session = new ResolverSession(defaultPayload, { baseline: "beginning" });
+  assert.ok(
+    new ByProblemPolicy(defaultPayload.problems.map((problem) => problem.id)).select(session),
+  );
+  assert.ok(new ByContestantPolicy().select(session));
+});
+
+test("autoplay waits for a settled step and pauses on a reported beat", async () => {
+  let steps = 0;
+  let resolvePaused;
+  const paused = new Promise((resolve) => {
+    resolvePaused = resolve;
+  });
+  const controller = new AutoplayController({
+    step: async () => {
+      steps += 1;
+      return { complete: false, pauseReason: "Rank changed." };
+    },
+    onChange: (state) => {
+      if (state.pauseKind === "beat") {
+        resolvePaused(state);
+      }
+    },
+  });
+  controller.play();
+  const state = await paused;
+  assert.equal(steps, 1);
+  assert.equal(state.playing, false);
+  assert.equal(state.pauseReason, "Rank changed.");
+});
+
+test("autoplay can be paused while the current reveal is still settling", async () => {
+  let resolveStep;
+  let steps = 0;
+  const stepSettled = new Promise((resolve) => {
+    resolveStep = resolve;
+  });
+  const controller = new AutoplayController({
+    step: async () => {
+      steps += 1;
+      return stepSettled;
+    },
+  });
+  controller.play();
+  await Promise.resolve();
+  controller.pause("Operator pause.");
+  resolveStep({ complete: false, pauseReason: null });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(steps, 1);
+  assert.equal(controller.getState().playing, false);
+  assert.equal(controller.getState().pauseReason, "Operator pause.");
+});

--- a/resources/resolver/tests/resolver.test.js
+++ b/resources/resolver/tests/resolver.test.js
@@ -6,13 +6,7 @@ import {
   UnsupportedResolverBaselineError,
   UnsupportedResolverFormatError,
 } from "../core.js";
-import {
-  AutoplayController,
-  CEREMONY_PRESETS,
-  SPEED_PRESETS,
-  getPauseReason,
-  normalizeAwardPlaces,
-} from "../controller.js";
+import { CEREMONY_PRESETS, SPEED_PRESETS, normalizeAwardPlaces } from "../controller.js";
 import { rankContestants } from "../ranking.js";
 import {
   BottomUpStickyPolicy,
@@ -22,7 +16,12 @@ import {
   selectByContestantTarget,
   selectByProblemTarget,
 } from "../policies.js";
-import { deriveProblemStats, getCellPresentation } from "../presentation.js";
+import {
+  deriveProblemStats,
+  getCellPresentation,
+  getOrganizationPresentation,
+  normalizeRankDisplayOption,
+} from "../presentation.js";
 import { roundLikePython } from "../utils.js";
 import {
   defaultPayload,
@@ -76,6 +75,11 @@ function assertFinalParity(session, payload, expectedRanks, expectedOrder) {
       expectedOrder,
     );
   }
+
+  assert.deepEqual(
+    deriveProblemStats(payload, state).map((stat) => stat.totalSolved),
+    payload.problems.map((problem) => problem.final_total_ac),
+  );
 }
 
 test("Default beginning baseline handles partial and zero scores without problem indexes", () => {
@@ -104,7 +108,7 @@ test("Default beginning baseline handles partial and zero scores without problem
     { score: 0, cumtime: 0 },
   );
 
-  assertFinalParity(session, defaultPayload, { 11: 1, 22: 1, 33: 3 });
+  assertFinalParity(session, defaultPayload, { 11: 1, 22: 1, 33: 3 }, [22, 11, 33]);
   const tied = session.getState().standings.filter((standing) => standing.rank === 1);
   assert.equal(tied.length, 2);
 });
@@ -114,6 +118,10 @@ test("ICPC official freeze preserves minutes, configured penalty, pending failur
     baseline: "official-freeze",
     seed: "icpc-seed",
   });
+  assert.deepEqual(
+    session.getState().standings.map((standing) => standing.contestantId),
+    [303, 202, 101],
+  );
   assert.deepEqual(session.getResolvableCells(), [
     { contestantId: 101, problemId: 42 },
     { contestantId: 101, problemId: 88 },
@@ -140,9 +148,10 @@ test("ICPC official freeze preserves minutes, configured penalty, pending failur
   );
 
   assertFinalParity(session, icpcPayload, { 101: 3, 202: 1, 303: 1 });
-  const order = session.getState().standings.map((standing) => standing.contestantId);
-  assert.equal(order.indexOf(202) < order.indexOf(101), true);
-  assert.equal(order.indexOf(303) < order.indexOf(101), true);
+  assert.deepEqual(
+    session.getState().standings.map((standing) => standing.contestantId),
+    [303, 202, 101],
+  );
 });
 
 test("ICPC beginning baseline scores an AC after wrong tries independently of freeze", () => {
@@ -203,7 +212,7 @@ test("VNOJ penalty zero ignores stored cell penalty counts", () => {
   assertFinalParity(session, vnojNoPenaltyPayload, { 701: 1 }, [701]);
 });
 
-test("ranking uses tie-aware displayed ranks and deterministic fallback, not submission count", () => {
+test("ranking keeps tie-aware displayed ranks while accepting an explicit physical fallback", () => {
   const ranked = rankContestants([
     { participationId: 1, isDisqualified: false, score: 10, cumtime: 20, tiebreaker: 5, tieKey: 9 },
     { participationId: 2, isDisqualified: false, score: 10, cumtime: 20, tiebreaker: 5, tieKey: 1 },
@@ -328,7 +337,7 @@ test("bottom-up sticky policy selects the current lowest unresolved contestant a
   }
 });
 
-test("derived Total AC and first solve only use the current revealed state", () => {
+test("derived Total AC uses revealed state while first solve remains authoritative", () => {
   const session = new ResolverSession(defaultPayload, {
     baseline: "beginning",
     seed: "presentation",
@@ -346,7 +355,7 @@ test("derived Total AC and first solve only use the current revealed state", () 
   stats = deriveProblemStats(defaultPayload, session.getState());
   assert.deepEqual(
     [stats[0].totalSolved, stats[0].firstSolveContestantId, stats[0].firstSolveTime],
-    [1, 22, 180],
+    [1, null, null],
   );
   session.revealCell(11, 101);
   stats = deriveProblemStats(defaultPayload, session.getState());
@@ -364,13 +373,41 @@ test("frozen ICPC presentation hides final solve time until reveal", () => {
   const contestant = getContestant(session, 101);
   const pending = getCellPresentation("icpc", contestant.problems["88"], 3);
   assert.equal(pending.primary, "2 tries");
-  assert.equal(pending.secondary, "Pending");
+  assert.equal(pending.secondary, "");
   assert.equal(pending.accessibleLabel.includes("60"), false);
 
   session.revealCell(101, 88);
   const revealed = getCellPresentation("icpc", getContestant(session, 101).problems["88"], 3);
   assert.equal(revealed.primary, "60");
   assert.equal(revealed.secondary, "2 tries");
+});
+
+test("VNOJ cell presentation matches frozen pending and revealed penalty structure", () => {
+  const session = new ResolverSession(vnojPayload, { baseline: "official-freeze" });
+  let cell = getContestant(session, 501).problems["9"];
+  let presentation = getCellPresentation("vnoj", cell, 3);
+  assert.deepEqual(
+    {
+      primary: presentation.primary,
+      secondary: presentation.secondary,
+      pendingCount: presentation.pendingCount,
+      penalty: presentation.penalty,
+    },
+    { primary: "50?", secondary: "?", pendingCount: 2, penalty: 0 },
+  );
+
+  session.revealCell(501, 9);
+  cell = getContestant(session, 501).problems["9"];
+  presentation = getCellPresentation("vnoj", cell, 3);
+  assert.deepEqual(
+    {
+      primary: presentation.primary,
+      secondary: presentation.secondary,
+      pendingCount: presentation.pendingCount,
+      penalty: presentation.penalty,
+    },
+    { primary: "100", secondary: "10:00", pendingCount: 0, penalty: 2 },
+  );
 });
 
 test("Phase 3 presets are deterministic and Director never starts an automatic policy", () => {
@@ -380,11 +417,14 @@ test("Phase 3 presets are deterministic and Director never starts an automatic p
       policy: CEREMONY_PRESETS.icpc.policy,
       tieOrder: CEREMONY_PRESETS.icpc.tieOrder,
     },
-    { baseline: "auto", policy: "bottom-up-sticky", tieOrder: "seeded" },
+    { baseline: "auto", policy: "row-sweep", tieOrder: "seeded" },
   );
   assert.equal(CEREMONY_PRESETS.full.baseline, "beginning");
   assert.equal(CEREMONY_PRESETS.director.policy, "manual");
-  assert.equal(SPEED_PRESETS.length, 4);
+  assert.deepEqual(
+    SPEED_PRESETS.map((preset) => preset.speed),
+    [0.5, 1, 2, 4],
+  );
   assert.equal(normalizeAwardPlaces(20, 8), 8);
   assert.equal(normalizeAwardPlaces(0, 8), 0);
 });
@@ -409,7 +449,7 @@ test("source tie order is explicit while seeded Replay restores the exact baseli
   assert.deepEqual(seeded.replay(), baseline);
 });
 
-test("semantic transition effects detect first solve and ceremony pause beats", () => {
+test("semantic transition effects use authoritative first solve metadata", () => {
   const session = new ResolverSession(defaultPayload, {
     baseline: "beginning",
     seed: "phase-3-effects",
@@ -417,25 +457,29 @@ test("semantic transition effects detect first solve and ceremony pause beats", 
   const first = session.revealCell(11, 101);
   const later = session.revealCell(22, 101);
   assert.equal(first.effects.firstSolveAppeared, true);
+  assert.equal(first.effects.authoritativeFirstSolveAppeared, true);
   assert.equal(later.effects.firstSolveAppeared, false);
+});
 
+test("authoritative first solve identity is stable regardless of reveal order", () => {
+  const laterFirst = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    seed: "fts-later-first",
+  });
+  const nonAuthoritative = laterFirst.revealCell(22, 101);
+  const authoritative = laterFirst.revealCell(11, 101);
+  assert.equal(nonAuthoritative.effects.authoritativeFirstSolveAppeared, false);
+  assert.equal(authoritative.effects.authoritativeFirstSolveAppeared, true);
+
+  const authoritativeFirst = new ResolverSession(defaultPayload, {
+    baseline: "beginning",
+    seed: "fts-authoritative-first",
+  });
   assert.equal(
-    getPauseReason(
-      [
-        {
-          effects: {
-            rankBefore: 5,
-            rankAfter: 3,
-            contestantFinished: false,
-            firstSolveAppeared: false,
-          },
-        },
-      ],
-      { rankChange: true, awardZone: true, contestantFinished: true, firstSolve: true },
-      3,
-    ),
-    "Entered the top 3 award zone.",
+    authoritativeFirst.revealCell(11, 101).effects.authoritativeFirstSolveAppeared,
+    true,
   );
+  assert.equal(defaultPayload.problems[0].first_solve_participation_id, 11);
 });
 
 test("by-problem and by-contestant policies choose semantic IDs without table columns", () => {
@@ -465,49 +509,26 @@ test("by-problem and by-contestant policies choose semantic IDs without table co
   assert.ok(new ByContestantPolicy().select(session));
 });
 
-test("autoplay waits for a settled step and pauses on a reported beat", async () => {
-  let steps = 0;
-  let resolvePaused;
-  const paused = new Promise((resolve) => {
-    resolvePaused = resolve;
-  });
-  const controller = new AutoplayController({
-    step: async () => {
-      steps += 1;
-      return { complete: false, pauseReason: "Rank changed." };
-    },
-    onChange: (state) => {
-      if (state.pauseKind === "beat") {
-        resolvePaused(state);
-      }
-    },
-  });
-  controller.play();
-  const state = await paused;
-  assert.equal(steps, 1);
-  assert.equal(state.playing, false);
-  assert.equal(state.pauseReason, "Rank changed.");
+test("rank display options accept Avatar, Logo, and Hidden and fail safely to Hidden", () => {
+  assert.equal(normalizeRankDisplayOption(1), 1);
+  assert.equal(normalizeRankDisplayOption(2), 2);
+  assert.equal(normalizeRankDisplayOption(3), 3);
+  assert.equal(normalizeRankDisplayOption(undefined), 3);
+  assert.equal(normalizeRankDisplayOption(null), 3);
+  assert.equal(normalizeRankDisplayOption(99), 3);
 });
 
-test("autoplay can be paused while the current reveal is still settling", async () => {
-  let resolveStep;
-  let steps = 0;
-  const stepSettled = new Promise((resolve) => {
-    resolveStep = resolve;
-  });
-  const controller = new AutoplayController({
-    step: async () => {
-      steps += 1;
-      return stepSettled;
-    },
-  });
-  controller.play();
-  await Promise.resolve();
-  controller.pause("Operator pause.");
-  resolveStep({ complete: false, pauseReason: null });
-  await Promise.resolve();
-  await Promise.resolve();
-  assert.equal(steps, 1);
-  assert.equal(controller.getState().playing, false);
-  assert.equal(controller.getState().pauseReason, "Operator pause.");
+test("multiple visible organizations retain display order, labels, and links", () => {
+  assert.deepEqual(
+    getOrganizationPresentation([
+      { name: "Alpha Organization", short_name: "AO", url: "/organization/alpha" },
+      { name: "Beta Organization", short_name: "", url: "/organization/beta" },
+      { name: "", short_name: "", url: "/organization/invalid" },
+    ]),
+    [
+      { label: "AO", url: "/organization/alpha" },
+      { label: "Beta Organization", url: "/organization/beta" },
+    ],
+  );
+  assert.deepEqual(getOrganizationPresentation(null), []);
 });

--- a/resources/resolver/tests/ui-contract.test.js
+++ b/resources/resolver/tests/ui-contract.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("award configuration does not permanently recolor ranking rows", async () => {
+  const [css, page] = await Promise.all([
+    readFile(new URL("../resolver.css", import.meta.url), "utf8"),
+    readFile(new URL("../page.js", import.meta.url), "utf8"),
+  ]);
+  assert.equal(css.includes("resolver-row--award"), false);
+  assert.equal(page.includes("resolver-row--award"), false);
+  assert.equal(page.includes("resolver-row--award-first"), false);
+});
+
+test("avatar and logo visuals keep separate shapes", async () => {
+  const css = await readFile(new URL("../resolver.css", import.meta.url), "utf8");
+  assert.match(css, /\.resolver-contestant__avatar\s*\{[^}]*border-radius:\s*50%/s);
+  assert.match(
+    css,
+    /\.resolver-contestant__identity \.resolver-contestant__visual--logo\s*\{[^}]*border-radius:\s*0\.15rem/s,
+  );
+  assert.match(css, /\.resolver-contestant__visual--logo img\s*\{[^}]*object-fit:\s*contain/s);
+});

--- a/resources/resolver/timing.js
+++ b/resources/resolver/timing.js
@@ -1,0 +1,112 @@
+export const RESOLUTION_STEP_TYPES = Object.freeze({
+  SCROLL_ROW: "SCROLL_ROW",
+  SELECT_TEAM: "SELECT_TEAM",
+  SELECT_PROBLEM: "SELECT_PROBLEM",
+  SELECT_SUBMISSION: "SELECT_SUBMISSION",
+  REVEAL_CELL: "REVEAL_CELL",
+  RESULT_MOVE: "RESULT_MOVE",
+  RESULT_STAY: "RESULT_STAY",
+  RESULT_FAILED: "RESULT_FAILED",
+  DESELECT: "DESELECT",
+  DELAY: "DELAY",
+  PAUSE: "PAUSE",
+});
+
+export const ICPC_EVENT_DELAYS_MS = Object.freeze({
+  SELECT_TEAM: 1300,
+  SELECT_PROBLEM: 1000,
+  RESULT_MOVE: 2250,
+  RESULT_STAY: 1500,
+  RESULT_FAILED: 850,
+  DESELECT: 250,
+  SELECT_SUBMISSION: 450,
+});
+
+export function effectiveDelay(baseDelay, playbackSpeed) {
+  const speed = Number(playbackSpeed);
+  if (!Number.isFinite(speed) || speed <= 0) {
+    throw new RangeError("Resolver playback speed must be greater than zero.");
+  }
+  return Number(baseDelay) / speed;
+}
+
+function action(type, metadata) {
+  return { type, ...metadata };
+}
+
+function delay(afterType) {
+  return action(RESOLUTION_STEP_TYPES.DELAY, {
+    afterType,
+    durationMs: ICPC_EVENT_DELAYS_MS[afterType],
+  });
+}
+
+function pause(kind, reason) {
+  return action(RESOLUTION_STEP_TYPES.PAUSE, { kind, reason });
+}
+
+function stepDetails(metadata) {
+  return {
+    target: metadata.target,
+    contestantLabel: metadata.contestantLabel,
+    problemLabel: metadata.problemLabel,
+    currentPosition: metadata.currentPosition,
+    actualPositionAfterReveal: metadata.actualPositionAfterReveal,
+    movementDelta: metadata.movementDelta,
+  };
+}
+
+function commonPrefix(metadata) {
+  const details = stepDetails(metadata);
+  return [
+    action(RESOLUTION_STEP_TYPES.SCROLL_ROW, details),
+    action(RESOLUTION_STEP_TYPES.SELECT_TEAM, details),
+  ];
+}
+
+export class ScoreboardTiming {
+  buildSteps(metadata) {
+    const details = stepDetails(metadata);
+    const steps = [
+      ...commonPrefix(metadata),
+      delay(RESOLUTION_STEP_TYPES.SELECT_TEAM),
+      action(RESOLUTION_STEP_TYPES.SELECT_PROBLEM, details),
+      delay(RESOLUTION_STEP_TYPES.SELECT_PROBLEM),
+      action(RESOLUTION_STEP_TYPES.REVEAL_CELL, details),
+      action(metadata.resultType, details),
+      delay(metadata.resultType),
+    ];
+    if (metadata.hardPauseReason) {
+      steps.push(pause(metadata.hardPauseKind, metadata.hardPauseReason));
+    }
+    steps.push(
+      action(RESOLUTION_STEP_TYPES.DESELECT, details),
+      delay(RESOLUTION_STEP_TYPES.DESELECT),
+    );
+    return steps;
+  }
+}
+
+export class SingleStepTiming {
+  buildSteps(metadata) {
+    const details = stepDetails(metadata);
+    return [
+      ...commonPrefix(metadata),
+      pause("single-step-team", `Selected ${metadata.contestantLabel}.`),
+      action(RESOLUTION_STEP_TYPES.SELECT_PROBLEM, details),
+      pause("single-step-problem", `Selected problem ${metadata.problemLabel}.`),
+      action(RESOLUTION_STEP_TYPES.REVEAL_CELL, details),
+      action(metadata.resultType, details),
+      pause(
+        metadata.hardPauseKind ?? "single-step-result",
+        metadata.hardPauseReason ?? `Revealed problem ${metadata.problemLabel}.`,
+      ),
+      action(RESOLUTION_STEP_TYPES.DESELECT, details),
+    ];
+  }
+}
+
+export function usesSingleStepTiming(displayedRank, singleStepStartRank) {
+  const threshold = Number.parseInt(singleStepStartRank, 10);
+  return Number.isFinite(threshold) && threshold > 0 && displayedRank <= threshold;
+}

--- a/resources/resolver/utils.js
+++ b/resources/resolver/utils.js
@@ -1,0 +1,111 @@
+export function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function deepFreeze(value) {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+  Object.freeze(value);
+  Object.values(value).forEach(deepFreeze);
+  return value;
+}
+
+export function roundLikePython(value, digits = 0) {
+  if (!Number.isFinite(value)) {
+    throw new TypeError("Resolver metrics must be finite numbers.");
+  }
+  if (!Number.isInteger(digits) || digits < 0 || digits > 10) {
+    throw new RangeError("Resolver score precision must be an integer between 0 and 10.");
+  }
+
+  const absolute = Math.abs(value);
+  if (absolute === 0) {
+    return value;
+  }
+
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setFloat64(0, absolute, false);
+  const high = view.getUint32(0, false);
+  const low = view.getUint32(4, false);
+  const exponentBits = (high >>> 20) & 0x7ff;
+  const fraction = (BigInt(high & 0xfffff) << 32n) | BigInt(low);
+  const significand = exponentBits === 0 ? fraction : (1n << 52n) | fraction;
+  const binaryExponent = exponentBits === 0 ? -1074 : exponentBits - 1075;
+  const decimalFactor = 10n ** BigInt(digits);
+
+  let numerator = significand * decimalFactor;
+  let denominator = 1n;
+  if (binaryExponent >= 0) {
+    numerator <<= BigInt(binaryExponent);
+  } else {
+    denominator <<= BigInt(-binaryExponent);
+  }
+
+  let rounded = numerator / denominator;
+  const remainder = numerator % denominator;
+  const comparison = remainder * 2n - denominator;
+  if (comparison > 0n || (comparison === 0n && rounded % 2n !== 0n)) {
+    rounded += 1n;
+  }
+
+  const result = Number(rounded) / Number(decimalFactor);
+  return value < 0 ? -result : result;
+}
+
+export function numeric(value, fallback = 0) {
+  return value === null || value === undefined ? fallback : Number(value);
+}
+
+export function cellState(problem, raw, extra = {}) {
+  if (raw === null) {
+    return {
+      state: "empty",
+      points: 0,
+      score: null,
+      time: 0,
+      tries: null,
+      penalty: null,
+      pending: 0,
+      attempted: false,
+      revealed: true,
+      ...extra,
+    };
+  }
+
+  const points = numeric(raw.points);
+  let state = "failed";
+  if (points === numeric(problem.max_score)) {
+    state = "solved";
+  } else if (points !== 0) {
+    state = "partial";
+  }
+
+  return {
+    state,
+    points,
+    score: points,
+    time: numeric(raw.time),
+    tries: raw.tries === undefined ? null : numeric(raw.tries),
+    penalty: raw.penalty === undefined ? null : numeric(raw.penalty),
+    pending: numeric(raw.pending),
+    attempted: true,
+    revealed: true,
+    ...extra,
+  };
+}
+
+export function hiddenCell() {
+  return {
+    state: "hidden",
+    points: 0,
+    score: null,
+    time: 0,
+    tries: null,
+    penalty: null,
+    pending: 0,
+    attempted: true,
+    revealed: false,
+  };
+}

--- a/templates/contest/contest-tabs.html
+++ b/templates/contest/contest-tabs.html
@@ -7,7 +7,7 @@
     {% endif %}
 
     {% if contest.start_time <= now or perms.judge.see_private_contest %}
-        {% if contest.allow_spotlight or perms.judge.can_view_spotlight %}
+        {% if can_edit or perms.judge.can_view_spotlight %}
             {{ make_tab('spotlight_ranking', 'fa-star-half-o', url('spotlight_ranking', contest.key), _('Spotlight Ranking'))}}
         {% endif %}
         {% if contest.can_see_own_scoreboard(request.user) %}

--- a/templates/contest/spotlight-ranking.html
+++ b/templates/contest/spotlight-ranking.html
@@ -1,823 +1,296 @@
-{% extends "user/base-users.html" %}
-
-{% block title_ruler %}{% endblock %}
-
-{% block title_row %}
-    {% include "contest/contest-tabs.html" %}
-{% endblock %}
-
-{% block users_media %}
-    {% if is_ICPC_format %}
-        {% include "contest/media-icpc-css.html" %}
-    {% else %}
-        {% include "contest/media-css.html" %}
-    {% endif %}
-
-    <style>
-        .select2-selection__arrow {
-            display: none;
-        }
-
-        .select2-selection__rendered {
-            cursor: text;
-            overflow: initial !important
-        }
-
-        .select2-results__option {
-            white-space: nowrap;
-        }
-
-        #search-contest, #search-contest + .select2 {
-            margin-top: 0.5em;
-        }
-
-        #search-contest {
-            width: 200px;
-            height: 2.3em;
-        }
-
-        .filter-checklist-button {
-            float: right;
-        }
-            
-        .full-score { 
-            background: none !important; 
-        }
-
-        td.partial-score a,
-        td.full-score a,
-        td.failed-score a {
-            opacity: 0;
-            transition: opacity 0.4s ease;
-        }
-
-        td a.visible {
-            opacity: 1;
-        }
-
-        #ranking-table { 
-            opacity: 0; 
-            transition: opacity 0.4s ease; 
-        }
-
-        #ranking-table.visible { 
-            opacity: 1; 
-        }
-
-        #ranking-table tr { 
-            will-change: transform, background-color; 
-        }
-
-        .highlight { 
-            background-color: #fff7b2 !important; 
-        }
-
-        @keyframes yellowFade {
-            0% { background-color: transparent; }
-            30% { background-color: #fff7b2; }
-            100% { background-color: transparent; }
-        }
-
-        .cell-change { 
-            animation: yellowFade 3s ease; 
-        }
-
-        .ranking-column div {
-            opacity: 0;
-            transition: opacity 0.6s ease;
-        }
-
-        .ranking-column div.visible { 
-            opacity: 1; 
-        }
-        
-        #next-user {
-            display: inline-block;
-            margin-left: 8px;
-            font-weight: bold;
-            color: #007bff;
-            vertical-align: bottom;
-        }
-    </style>
-{% endblock %}
-
-{% block users_js_media %}
-    {% if not contest.ended %}
-        <script type="text/javascript">
-            $(function () {
-                window.install_tooltips = function () {
-                    $('td.user-name').find('> span:first-child').each(function () {
-                        var link = $(this);
-                        link.mouseenter(function (e) {
-                            var start_time = link.siblings('.start-time').text().trim();
-                            link.addClass('tooltipped tooltipped-e').attr('aria-label', start_time);
-                        }).mouseleave(function (e) {
-                            link.removeClass('tooltipped tooltipped-e').removeAttr('aria-label');
-                        });
-                    });
-                };
-
-                install_tooltips();
-            });
-        </script>
-    {% endif %}
-    <script type="text/javascript">
-        $(function () {
-            var url = '{{ url('contest_participation', contest.key, '__username__') }}';
-            var placeholder = $('#search-contest').replaceWith($('<select>').attr({
-                id: 'search-contest'
-            })).attr('placeholder');
-
-            $('#search-contest').select2({
-                theme: '{{ DMOJ_SELECT2_THEME }}',
-                placeholder: placeholder,
-                ajax: {
-                    url: '{{ url('contest_user_search_select2_ajax', contest.key) }}',
-                    delay: 300
-                },
-                minimumInputLength: 1,
-                templateResult: function (data) {
-                    return $('<span>')
-                        .append($('<img>', {
-                            class: 'user-search-image',
-                            src: data.gravatar_url,
-                            width: 24,
-                            height: 24,
-                        }))
-                        .append($('<span>', {
-                            class: data.display_rank + ' user-search-name',
-                        }).text(data.text));
-                }
-            }).on('change', function () {
-                window.location.href = url.replace('__username__', $(this).val());
-            });
-
-            $('#show-personal-info-checkbox').click(function () {
-                $('.personal-info').toggle();
-                localStorage.setItem('show-personal-info', $('.personal-info').is(':visible') ? 'true' : 'false');
-            });
-
-            if (localStorage.getItem('show-personal-info') == 'true') {
-                $('.personal-info').show();
-                $('#show-personal-info-checkbox').prop('checked', true);
-            }
-
-            {% if show_virtual %}
-                $('#show-virtual-participations-checkbox').prop('checked', true);
-            {% endif %}
-
-            $('#show-virtual-participations-checkbox').click(function () {
-                const parser = new URL(window.location.href);
-                parser.searchParams.set('show_virtual', '{{ 'false' if show_virtual else 'true' }}');
-                window.location.href = parser.href;
-            });
-
-            var contest_key = '{{contest.key}}';
-
-            $("a#cache_alert").click(function () {
-                var $closer = $(this);
-                $closer.parent().hide();
-                localStorage.setItem(`hide-cache-alert-${contest_key}`, 'true');
-            });
-
-            if (localStorage.getItem(`hide-cache-alert-${contest_key}`) == 'true') {
-                $("a#cache_alert").click();
-            }
-
-            $("a#frozen_alert").click(function () {
-                var $closer = $(this);
-                $closer.parent().hide();
-                localStorage.setItem(`hide-frozen-alert-${contest_key}`, 'true');
-            });
-
-            if (localStorage.getItem(`hide-frozen-alert-${contest_key}`) == 'true') {
-                $("a#frozen_alert").click();
-            }
-
-            // hack to keep scroll position after selecting option
-            // https://stackoverflow.com/questions/55045146/select2-do-not-scroll-on-selection
-            // scrollAfterSelect is only available after v4.0.6
-            $(function() {
-                $('#org-check-list').select2({
-                    theme: '{{ DMOJ_SELECT2_THEME }}',
-                    multiple: true,
-                    closeOnSelect: false,
-                    placeholder: '{{ _('Search organizations') }}',
-                });
-
-                var selection = $('#org-check-list').data().select2.selection;
-                var results = $('#org-check-list').data().select2.results;
-
-                $('#org-check-list').on('select2:selecting', function(e) {
-                    let id = e.params.args.data.id;
-                    let val = $(e.target).val().concat([id]);
-                    $(e.target).val(val).trigger('change');
-
-                    if (selection.$search.val() != '') {
-                        selection.$search.val('');
-                        selection.trigger('query', {});
-                    } else {
-                        results.setClasses();
-                    }
-
-                    return false;
-                });
-
-                $('#org-check-list').on('select2:unselecting', function(e) {
-                    let id = e.params.args.data.id;
-                    let val = $(e.target).val().filter(function(v) { return v != id; });
-                    $(e.target).val(val).trigger('change');
-
-                    if (selection.$search.val() != '') {
-                        selection.$search.val('');
-                        selection.trigger('query', {});
-                    } else {
-                        results.setClasses();
-                    }
-
-                    return false;
-                });
-
-                $('#org-check-list').data().select2.toggleDropdown = function () {
-                    selection.$search.trigger('focus');
-
-                    if (!this.isOpen()) {
-                        this.open();
-                    }
-                }
-
-                $('#filter-by-organization-button').click(function () {
-                    $('#org-check-list-wrapper').toggle();
-                    $('#org-check-list').select2('open');
-                });
-            });
-
-            if (localStorage.getItem(`filter-cleared-${contest_key}`) === null) {
-                localStorage.setItem(`filter-cleared-${contest_key}`, 'true');
-            }
-
-            if (localStorage.getItem(`filter-selected-orgs-${contest_key}`) === null) {
-                localStorage.setItem(`filter-selected-orgs-${contest_key}`, []);
-            }
-
-            $('#apply-organization-filter').click(function () {
-                $('#org-check-list-wrapper').hide();
-
-                let selected_orgs = $('#org-check-list').val().map(x => x.trim());
-                localStorage.setItem(`filter-selected-orgs-${contest_key}`, selected_orgs);
-                window.applyRankingFilter();
-            });
-
-            $('#clear-organization-filter').click(function () {
-                $('#org-check-list').val(null).trigger('change');
-                $('#apply-organization-filter').click();
-            });
-
-            // hide checklist by clicking outside
-            $(document).mouseup(function (e) {
-                e.stopPropagation();
-
-                // if clicked on the filter button
-                // then this function should not do anything
-                if ($('#filter-by-organization-button').has(e.target).length !== 0) {
-                    return;
-                }
-
-                if ($('#select2-org-check-list-results').has(e.target).length !== 0) {
-                    return;
-                }
-
-                if ($(e.target).attr('id') && $(e.target).attr('id').startsWith('select2-org-check-list-result')) {
-                    return;
-                }
-
-                // check if the clicked area is the checklist or not
-                if ($('#org-dropdown-check-list').has(e.target).length === 0) {
-                    $('#apply-organization-filter').click();
-                }
-            });
-
-            window.getOrganizationCodes = function () {
-                let org_list = []
-
-                $('#ranking-table > tbody > *').each(function () {
-                    let org_anchor = $(this).find("div > div > .personal-info > .organization > a")[0];
-
-                    if (org_anchor) {
-                        org_list.push(org_anchor.text);
-                    }
-                });
-
-                org_list.sort();
-                org_list.push("Other");
-
-                org_list = new Set(org_list);
-
-                let org_options = $('#org-check-list');
-                org_options.empty();
-
-                org_list.forEach(function (org) {
-                    org_options.append(
-                        `<option value="${org}">${org}</option>`
-                    );
-                });
-            };
-
-            window.getOrganizationCodes();
-
-            function extractCurrentAbsRank(row_text) {
-                let paren_surround_text = row_text.match(/\(([^)]+)\)/);
-                let current_abs_rank
-                    = (paren_surround_text !== null)
-                    ? paren_surround_text[1]
-                    : row_text;
-                return current_abs_rank;
-            }
-
-            window.clearRankingFilter = function () {
-                if (localStorage.getItem(`filter-cleared-${contest_key}`) == 'true') {
-                    return;
-                }
-
-                $('#ranking-table > tbody > tr[id]').each(function () {
-                    $(this).show();
-                    $(this).find("td")[0].innerHTML = extractCurrentAbsRank($(this).find("td")[0].innerText);
-                });
-
-                localStorage.setItem(`filter-cleared-${contest_key}`, 'true');
-            };
-
-            window.applyRankingFilter = function () {
-                let counter = 0;
-                let previous_abs_rank = -1;
-                let selected_orgs = localStorage.getItem(`filter-selected-orgs-${contest_key}`);
-
-                if (!selected_orgs.length) {
-                    window.clearRankingFilter();
-                    return;
-                }
-
-                $('#ranking-table > tbody > tr[id]').each(function () {
-                    let row = $(this);
-
-                    let org_anchor = row.find("div > div > .personal-info > .organization > a")[0];
-                    let org = org_anchor ? org_anchor.text : 'Other';
-
-                    if (!selected_orgs.includes(org.trim())) {
-                        row.hide();
-                        return;
-                    }
-
-                    row.show();
-                    let current_abs_rank = extractCurrentAbsRank(row.find("td")[0].innerText);
-
-                    if (previous_abs_rank == -1 || previous_abs_rank != current_abs_rank) {
-                        ++counter;
-                    }
-
-                    row.find("td")[0].innerHTML = `${counter}<br>(${current_abs_rank})`;
-                    previous_abs_rank = current_abs_rank;
-                });
-
-                if (counter > 0) {
-                    localStorage.setItem(`filter-cleared-${contest_key}`, 'false');
-                }
-            };
-
-            window.applyRankingFilter();
-
-            window.restoreChecklistOptions = function () {
-                let selected_orgs = localStorage.getItem(`filter-selected-orgs-${contest_key}`).split(',');
-                $('#org-check-list').val(selected_orgs).trigger('change');
-            };
-
-            window.restoreChecklistOptions();
-
-            window.enableAdminOperations = function () {
-                $('a.disqualify-participation').click(function (e) {
-                    e.preventDefault();
-                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to disqualify this participation?') }}"))
-                        $(this).closest('form').submit();
-                })
-                $('a.un-disqualify-participation').click(function (e) {
-                    e.preventDefault();
-                    if (e.ctrlKey || e.metaKey || confirm("{{ _('Are you sure you want to un-disqualify this participation?') }}"))
-                        $(this).closest('form').submit();
-                })
-            };
-
-            window.enableAdminOperations();
-        });
-
-        {% if tab == 'ranking' %}
-            $.fn.ignore = function(sel) {
-                return this.clone().find(sel || '>*').remove().end();
-            };
-
-            function download_table_as_csv() {
-                function clean_text(text) {
-                    // Remove new line and leading/trailing spaces
-                    text = text.replace(/(\r\n|\n|\r)/gm, '').trim();
-                    // Escape double-quote with double-double-quote
-                    text = text.replace(/"/g, '""');
-
-                    return '"' + text + '"';
-                }
-                (function() {
-    'use strict';
-    function e() {
-        var a = [];
-        $('#ranking-table thead tr').first().find('th').each(function() {
-            var t = $(this);
-            var s = t.find('.problem-code').text();
-            if (s === '') {
-                s = t.text();
-            }
-            s = s.trim();
-            if (s !== '' && !(t.hasClass('rank') || t.hasClass('username') || t.hasClass('rating-column'))) {
-                a.push(s);
-            }
-        });
-        a.shift();
-        var o = a.join('\n');
-        var b = new Blob([o], { type: "text/plain;charset=utf-8" });
-        var l = document.createElement('a');
-        l.href = URL.createObjectURL(b);
-        l.download = "id.txt";
-        document.body.appendChild(l);
-        l.click();
-        document.body.removeChild(l);
-    }
-    function d() {
-        var b = document.createElement('button');
-        b.innerText = "ID Bài";
-        b.style.position = 'fixed';
-        b.style.top = '20px';
-        b.style.right = '20px';
-        b.style.padding = '10px';
-        b.style.background = '#28a745';
-        b.style.color = 'white';
-        b.style.border = 'none';
-        b.style.borderRadius = '5px';
-        b.style.cursor = 'pointer';
-        b.addEventListener('click', e);
-        document.body.appendChild(b);
-    }
-
-    d();
-})();
-                var csv = [];
-
-                $('#ranking-table thead tr').each(function () {
-                    var header = [];
-                    $(this).find('th').each(function () {
-                        var $col = $(this);
-
-                        if ($col.hasClass('rating-column')) {
-                            // Skip rating
-                            return;
-                        } else if ($col.hasClass('rank')) {
-                            // Rank
-                            header.push(clean_text($col.text()));
-                        } else if ($col.hasClass('username')) {
-                            // Username and Full name
-                            header.push(clean_text('{{ _('Username') }}'));
-                            header.push(clean_text('{{ _('Full Name') }}'));
-                        } else {
-                            // Point
-                            var name = $col.find('.problem-code').text();
-                            if (name == '') {
-                                name = $col.text();
-                            }
-                            header.push(clean_text(name));
-                        }
-                    });
-                    csv.push(header.join(','));
-                });
-
-                $('#ranking-table tbody tr').each(function () {
-                    // Skip hidden row (due to filtering)
-                    if ($(this).is(':hidden')) {
-                        return;
-                    }
-
-                    var row_data = [];
-                    $(this).find('td').each(function () {
-                        var $col = $(this);
-
-                        if ($col.hasClass('rating-column')) {
-                            // Skip rating
-                            return;
-                        } else if ($col.hasClass('user-name')) {
-                            // Username and Full name
-                            row_data.push(clean_text($col.find('.rating').first().text()));
-                            row_data.push(clean_text($col.find('.personal-info').first().text()));
-                        } else {
-                            // Point or rank
-                            row_data.push(clean_text($col.ignore('.solving-time').text()));
-                        }
-                    });
-                    csv.push(row_data.join(','));
-                });
-
-                var csv_string = csv.join('\n');
-                var filename = 'ranking_{{ contest.key }}_' + moment().format('YYYY-MM-DD-HH-mm-ss') + '.csv';
-                var link = document.createElement('a');
-                link.style.display = 'none';
-                link.setAttribute('target', '_blank');
-                link.setAttribute('href', 'data:text/csv;charset=utf-8,\uFEFF' + encodeURIComponent(csv_string));
-                link.setAttribute('download', filename);
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-            }
-        {% endif %}
-    </script>
-    {% include "contest/media-js.html" %}
-{% endblock %}
-
-{% block before_users_table %}
-    <div style="margin-bottom: 1.25em">
-        {% if tab == 'participation' %}
-            {% if contest.can_see_full_scoreboard(request.user) %}
-                <input id="search-contest" type="text" placeholder="{{ _('View user participation') }}">
-            {% endif %}
-        {% endif %}
-        {% if tab == 'spotlight_ranking' %}
-            <div id="org-dropdown-check-list">
-                <button id="filter-by-organization-button" class="inline-button">
-                    <i class="tab-icon fa fa-filter"></i>
-                    <b>{{ _('Filter') }}</b>
-                </button>
-
-                <div id="org-check-list-wrapper">
-                    <div>
-                        <button id="apply-organization-filter" class="inline-button filter-checklist-button">{{ _('Apply') }}</button>
-                        <button id="clear-organization-filter" class="inline-button filter-checklist-button">{{ _('Clear') }}</button>
-                    </div>
-                    <select id="org-check-list" name="orgs[]" multiple="multiple"></select>
-                </div>
-            </div>
-            <button id="reveal-problem-btn" class="inline-button">Trình diễn theo bài</button>
-            <button id="reveal-user-btn" class="inline-button">Trình diễn theo người dùng</button>
-            <span id="next-user" style="font-weight:bold; color:#007bff;"></span>
-        {% endif %}
-        {% if tab != 'official_ranking' %}
-            <input id="show-personal-info-checkbox" type="checkbox" style="vertical-align: bottom">
-            <label for="show-personal-info-checkbox" style="vertical-align: bottom">{{ _('Show full name/organization') }}</label>
-        {% endif %}
-        {% if tab == 'ranking' %}
-            <input id="show-virtual-participations-checkbox" type="checkbox" style="vertical-align: bottom">
-            <label for="show-virtual-participations-checkbox" style="vertical-align: bottom">{{ _('Show virtual participations') }}</label>
-            {% if not is_ICPC_format %}
-            <a href="#" onclick="download_table_as_csv()" style="float: right;">{{ _('Download as CSV') }}</a>
-            {% endif %}
-        {% endif %}
-    </div>
-{% endblock %}
-
-{% block users_table %}
-{{ rendered_ranking_table }}
-<script>
-window.onload = function () {
-    alert_text=`Tính năng này đang trong giai đoạn thử nghiệm beta, tính năng này có thể gây xung đột với các tính năng khác, nếu bạn có bất cứ vấn đề gì vui lòng liên hệ với ban nghiên cứu và phát triển chtcoder! Xin cảm ơn.`
-    alert(alert_text)
-    const headerCells = document.querySelectorAll("#ranking-table thead th");
-    const exerciseStartIndex = 3; 
-    const totalExercises = headerCells.length - exerciseStartIndex;
-    let currentCol = exerciseStartIndex;
-    let currentUserIndex = 0;
-
-    const tableBody = document.querySelector("#ranking-table tbody");
-
-    function parseScore(str) {
-        return parseFloat((str || "0").replace(",", ".")) || 0;
-    }
-
-    function recalcTotal(row) {
-        let total = 0;
-        const cells = row.querySelectorAll("td");
-        for (let i = exerciseStartIndex; i < exerciseStartIndex + totalExercises; i++) {
-            const scoreCell = cells[i];
-            if (scoreCell) {
-                const a = scoreCell.querySelector("a");
-                if (a && a.classList.contains("visible")) {
-                    total += parseScore(a.innerText);
-                }
-            }
-        }
-        const totalCell = cells[2];
-        const totalLink = totalCell.querySelector("a");
-        totalCell.dataset.total = total;
-        totalLink.innerText = total.toFixed(3).replace(".", ",");
-        totalLink.classList.add("visible");
-        totalCell.classList.add("cell-change");
-        setTimeout(() => totalCell.classList.remove("cell-change"), 1000);
-    }
-
-    function updateZebra() {
-        tableBody.querySelectorAll("tr").forEach((row, i) => {
-            row.style.backgroundColor = (i % 2 === 0) ? "white" : "#f2f2f2";
-        });
-    }
-
-    function updateNextUserLabel() {
-        const rows = Array.from(tableBody.querySelectorAll("tr")).filter(r => r.querySelector(".user-points"));
-        const label = document.getElementById("next-user");
-        if (currentUserIndex < rows.length) {
-            const usernameCell = rows[currentUserIndex].querySelectorAll("td")[1];
-            if (usernameCell) {
-                label.textContent = "Tiếp theo: " + usernameCell.innerText;
-            }
-        } else {
-            label.textContent = "Đã mở hết tất cả người dùng";
-        }
-    }
-
-    (function initTable() {
-        let rows = Array.from(tableBody.querySelectorAll("tr"))
-            .filter(r => r.querySelector(".user-points"));
-
-
-        rows = rows.filter(row => {
-            const totalCell = row.querySelector(".user-points");
-            if (totalCell) {
-                let totalValue = parseFloat(totalCell.innerText.replace(",", "."));
-                console.log(totalValue);
-                if (totalValue === -9999) {
-                    console.log("hehe", row.id || row.innerText);
-                    row.remove(); 
-                    return false; 
-                }
-                totalCell.dataset.total = 0;
-                const link = totalCell.querySelector("a");
-                if (link) link.innerText = "0,000";
-            }
-            return true;
-    });
-
-    rows.sort((a, b) => {
-            const nameA = a.querySelectorAll("td")[1].innerText.toLowerCase();
-            const nameB = b.querySelectorAll("td")[1].innerText.toLowerCase();
-            return nameA.localeCompare(nameB);
-        });
-
-        rows.forEach(row => tableBody.appendChild(row));
-
-        updateZebra();
-        setTimeout(() => {
-            document.getElementById("ranking-table").classList.add("visible");
-        }, 300);
-        updateNextUserLabel();
-    })();
-
-
-    function revealColumnAndUpdateTotal(colIndex) {
-        const rows = Array.from(tableBody.querySelectorAll("tr")).filter(r => r.querySelector(".user-points"));
-        const firstPos = new Map();
-        rows.forEach(row => firstPos.set(row, row.getBoundingClientRect().top));
-
-        rows.forEach(row => {
-        const cells = row.querySelectorAll("td");
-        const scoreCell = cells[colIndex];
-        if (scoreCell) {
-            const a = scoreCell.querySelector("a");
-            if (a && !a.classList.contains("visible")) {
-                a.classList.add("visible");
-                scoreCell.classList.add("cell-change");
-                setTimeout(() => scoreCell.classList.remove("cell-change"), 1000);
-            }
-            recalcTotal(row);
-        }
-    });
-
-    const sortedRows = rows.slice().sort((a, b) => {
-        const totalA = parseFloat(a.querySelectorAll("td")[2].dataset.total) || 0;
-        const totalB = parseFloat(b.querySelectorAll("td")[2].dataset.total) || 0;
-        return totalB - totalA;
-    });
-    sortedRows.forEach(row => tableBody.appendChild(row));
-    const lastPos = new Map();
-    sortedRows.forEach(row => lastPos.set(row, row.getBoundingClientRect().top));
-    sortedRows.forEach((row, i) => {
-        const invertY = firstPos.get(row) - lastPos.get(row);
-        if (invertY !== 0) {
-            setTimeout(() => {
-                row.classList.add("highlight");
-                setTimeout(() => row.classList.remove("highlight"), 1500);
-            }, i * 150);
-        }
-        row.style.transform = `translateY(${invertY}px)`;
-        row.style.transition = "transform 0s";
-        requestAnimationFrame(() => {
-            row.style.transition = `transform 1.2s ease-in-out ${i * 0.15}s, background-color 1s ease ${i * 0.15}s`;
-            row.style.transform = "";
-        });
-    });
-    updateZebra();
-    }
-
-    document.getElementById("reveal-problem-btn").addEventListener("click", () => {
-        if (currentCol < exerciseStartIndex + totalExercises) {
-            revealColumnAndUpdateTotal(currentCol);
-            currentCol++;
-            if (currentCol >= exerciseStartIndex + totalExercises) {
-                setTimeout(() => {
-                    document.querySelectorAll(".ranking-column").forEach(td => {
-                        const div = td.querySelector("div");
-                        if (div) {
-                            div.classList.add("visible");
-                            td.classList.add("cell-change");
-                        }
-                    });
-                }, 500);
-            }
-        }
-    });
-
-    document.getElementById("reveal-user-btn").addEventListener("click", () => {
-        const rows = Array.from(tableBody.querySelectorAll("tr")).filter(r => r.querySelector(".user-points"));
-        if (currentUserIndex < rows.length) {
-            const row = rows[currentUserIndex];
-            for (let col = exerciseStartIndex; col < exerciseStartIndex + totalExercises; col++) {
-                const scoreCell = row.querySelectorAll("td")[col];
-                if (scoreCell) {
-                    const a = scoreCell.querySelector("a");
-                    if (a && !a.classList.contains("visible")) {
-                        a.classList.add("visible");
-                        scoreCell.classList.add("cell-change");
-                        setTimeout(() => scoreCell.classList.remove("cell-change"), 1000);
-                    }
-                    recalcTotal(row);
-                }
-            }
-            revealColumnAndUpdateTotal(-1);
-            currentUserIndex++;
-            updateNextUserLabel();
-
-            if (currentUserIndex >= rows.length) {
-                setTimeout(() => {
-                    document.querySelectorAll(".ranking-column").forEach(td => {
-                        const div = td.querySelector("div");
-                        if (div) {
-                            div.classList.add("visible");
-                            td.classList.add("cell-change");
-                        }
-                    });
-                }, 500);
-            }
-        }
-    });
-};
-</script>
-
-{% endblock %}
-
-{% block body %}
-    {% if is_frozen %}
-    <div class="alert-warning">
-        <p style="padding: 10px; text-align: center">
-        <a class="close" id="frozen_alert">x</a>
-        {%- trans frozen_minutes=contest.frozen_last_minutes -%}
-            The scoreboard was frozen with {{frozen_minutes}} minutes remaining - submissions in the last {{frozen_minutes}} minutes of the contest are still shown as pending.
-        {%- endtrans -%}
-    </p></div>
-    {% endif %}
-    {% if not contest.ended and cache_timeout %}
-        <div class="alert-warning alert-dismissable">
-            <p style="padding: 10px; text-align: center">
-            <a class="close" id="cache_alert">x</a>
-            {%- trans -%}
-                The scoreboard is cached for {{cache_timeout}} seconds, your submission might take some time before it appears here.
-            {%- endtrans -%}
-            </p>
+{% extends "user/base-users.html" %} {% block title_ruler %}{% endblock %} {% block title_row %} {%
+include "contest/contest-tabs.html" %} {% endblock %} {% block users_js_media %} {% if not
+resolver_error %}
+<script type="module" src="{{ static('resolver/bootstrap.js') }}"></script>
+{% endif %} {% endblock %} {% block users_media %} {% include "contest/media-css.html" %} {% if
+contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% endif %}
+<link rel="stylesheet" href="{{ static('resolver/resolver.css') }}" />
+{% endblock %} {% block users_table %} {% if resolver_error %}
+<div class="alert alert-danger" role="alert">{{ resolver_error }}</div>
+{% else %}
+<main
+  id="resolver-root"
+  class="resolver-page"
+  data-label-rank="{{ _('Rank') }}"
+  data-label-username="{{ _('Username') }}"
+  data-label-score="{{ _('Points') }}"
+  data-label-penalty="{{ _('Penalty') }}"
+  data-label-time="{{ _('Time') }}"
+  data-label-total-ac="{{ _('Total AC') }}"
+>
+  <section
+    id="resolver-setup"
+    class="resolver-setup"
+    aria-labelledby="resolver-setup-heading"
+    hidden
+  >
+    <h3 id="resolver-setup-heading" class="resolver-setup__heading">
+      <i class="fa fa-star-half-o"></i> {{ _('Resolver setup') }}
+    </h3>
+    <p class="resolver-setup__intro">
+      {{ _('Choose a ceremony preset, then adjust only what you need.') }}
+    </p>
+    <form id="resolver-setup-form">
+      <div class="resolver-presets" role="group" aria-label="{{ _('Resolver preset') }}">
+        <button
+          type="button"
+          class="inline-button resolver-button"
+          data-resolver-preset="icpc"
+          aria-pressed="true"
+        >
+          {{ _('ICPC Ceremony') }}
+        </button>
+        <button
+          type="button"
+          class="inline-button resolver-button"
+          data-resolver-preset="full"
+          aria-pressed="false"
+        >
+          {{ _('Full Reveal') }}
+        </button>
+        <button
+          type="button"
+          class="inline-button resolver-button"
+          data-resolver-preset="director"
+          aria-pressed="false"
+        >
+          {{ _('Director') }}
+        </button>
+      </div>
+      <div class="resolver-setup__grid">
+        <div class="resolver-field">
+          <label for="resolver-baseline">{{ _('Start state') }}</label>
+          <select id="resolver-baseline" name="baseline">
+            <option value="auto">{{ _('Auto') }}</option>
+            <option value="beginning">{{ _('Beginning') }}</option>
+            <option value="official-freeze">{{ _('Official freeze') }}</option>
+          </select>
+          <span class="resolver-field__help"
+            >{{ _('Beginning uses a deterministic non-spoiling tie order.') }}</span
+          >
         </div>
-    {% endif %}
-    {{ super() }}
-    {% if is_ICPC_format %}
-    <table id="cell_legend" class="table" style="width: 10em; margin-left: 0">
-        <thead>
-            <tr>
-                <th scope="col">{{_('Cell colours')}}</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="first-solve">
-                <td>{{_('Solved first')}}</td>
-            </tr>
-            <tr class="full-score">
-                <td>{{_('Solved')}}</td>
-            </tr>
-            <tr class="failed-score">
-                <td>{{_('Tried, incorrect')}}</td>
-            </tr>
-            <tr class="pending">
-                <td>{{_('Tried, pending')}}</td>
-            </tr>
-            <tr>
-                <td>{{_('Untried')}}</td>
-            </tr>
-        </tbody>
-    </table>
-    {% endif %}
-{% endblock %}
+        <div class="resolver-field">
+          <label for="resolver-policy">{{ _('Reveal order') }}</label>
+          <select id="resolver-policy" name="policy">
+            <option value="bottom-up-sticky">{{ _('Bottom-up sticky') }}</option>
+            <option value="by-problem">{{ _('By problem') }}</option>
+            <option value="by-contestant">{{ _('By contestant') }}</option>
+            <option value="manual">{{ _('Manual only') }}</option>
+          </select>
+          <span class="resolver-field__help"
+            >{{ _('Bottom-up keeps resolving the selected contestant before choosing a new
+            lowest-ranked target.') }}</span
+          >
+        </div>
+        <div class="resolver-field">
+          <label for="resolver-granularity">{{ _('Next control') }}</label>
+          <select id="resolver-granularity" name="granularity">
+            <option value="cell">{{ _('One cell') }}</option>
+            <option value="contestant">{{ _('Whole contestant') }}</option>
+          </select>
+          <span class="resolver-field__help"
+            >{{ _('The eye button reveals a whole contestant; Back still moves one cell at a time.')
+            }}</span
+          >
+        </div>
+        <div class="resolver-field">
+          <label for="resolver-tie-order">{{ _('Beginning tie order') }}</label>
+          <select id="resolver-tie-order" name="tie_order">
+            <option value="seeded">{{ _('Seeded shuffle') }}</option>
+            <option value="source">{{ _('Source order') }}</option>
+          </select>
+          <span class="resolver-field__help"
+            >{{ _('Seeded shuffle avoids exposing final order and replays identically.') }}</span
+          >
+        </div>
+        <div class="resolver-field">
+          <label for="resolver-speed">{{ _('Autoplay speed') }}</label>
+          <select id="resolver-speed" name="speed">
+            <option value="0">0.5×</option>
+            <option value="1" selected>1×</option>
+            <option value="2">1.5×</option>
+            <option value="3">2×</option>
+          </select>
+          <span class="resolver-field__help"
+            >{{ _('Speed changes the pause between settled reveals; row movement remains 700 ms.')
+            }}</span
+          >
+        </div>
+        <div class="resolver-field">
+          <label for="resolver-award-places">{{ _('Award places') }}</label>
+          <input id="resolver-award-places" name="award_places" type="number" min="0" value="3" />
+          <span class="resolver-field__help"
+            >{{ _('Use 0 to disable the current-state award-zone highlight.') }}</span
+          >
+        </div>
+        <fieldset class="resolver-field resolver-field--beats">
+          <legend>{{ _('Pause autoplay when') }}</legend>
+          <label><input name="pause_rank" type="checkbox" checked /> {{ _('Rank changes') }}</label>
+          <label
+            ><input name="pause_award" type="checkbox" checked /> {{ _('Enters award zone')
+            }}</label
+          >
+          <label
+            ><input name="pause_finished" type="checkbox" checked /> {{ _('Contestant is fully
+            resolved') }}</label
+          >
+          <label
+            ><input name="pause_first_solve" type="checkbox" checked /> {{ _('First solve appears')
+            }}</label
+          >
+        </fieldset>
+      </div>
+      <div class="resolver-setup__footer">
+        <p id="resolver-freeze-note" class="resolver-setup__note"></p>
+        <button type="submit" class="button resolver-button resolver-button--primary">
+          <i class="fa fa-play"></i> {{ _('Start resolver') }}
+        </button>
+      </div>
+    </form>
+  </section>
+
+  <section id="resolver-workspace" aria-label="{{ _('Resolver standings') }}" hidden>
+    <div class="resolver-toolbar" role="group" aria-label="{{ _('Resolver controls') }}">
+      <div class="resolver-toolbar__group">
+        <button
+          id="resolver-next"
+          type="button"
+          class="inline-button resolver-button resolver-button--primary"
+        >
+          {{ _('Reveal next cell') }}
+        </button>
+        <button id="resolver-play" type="button" class="inline-button resolver-button">
+          <i class="fa fa-play"></i> {{ _('Play') }}
+        </button>
+        <button
+          id="resolver-slower"
+          type="button"
+          class="inline-button resolver-button resolver-button--compact"
+          title="{{ _('Slower') }} ([)"
+          aria-label="{{ _('Slower autoplay') }}"
+        >
+          −
+        </button>
+        <span id="resolver-speed-label" class="resolver-speed-label">1×</span>
+        <button
+          id="resolver-faster"
+          type="button"
+          class="inline-button resolver-button resolver-button--compact"
+          title="{{ _('Faster') }} (])"
+          aria-label="{{ _('Faster autoplay') }}"
+        >
+          +
+        </button>
+        <button id="resolver-back" type="button" class="inline-button resolver-button">
+          <i class="fa fa-step-backward"></i> {{ _('Back') }}
+        </button>
+        <button id="resolver-forward" type="button" class="inline-button resolver-button">
+          {{ _('Forward') }}
+        </button>
+        <button id="resolver-reset" type="button" class="inline-button resolver-button">
+          <i class="fa fa-undo"></i> {{ _('Reset') }}
+        </button>
+        <button id="resolver-replay" type="button" class="inline-button resolver-button">
+          <i class="fa fa-repeat"></i> {{ _('Replay') }}
+        </button>
+      </div>
+      <div class="resolver-toolbar__group">
+        <span id="resolver-progress" class="resolver-progress"></span>
+        <button id="resolver-toggle-hud" type="button" class="inline-button resolver-button">
+          {{ _('HUD') }}
+        </button>
+        <button id="resolver-help" type="button" class="inline-button resolver-button">
+          {{ _('Shortcuts') }}
+        </button>
+        <button id="resolver-fullscreen" type="button" class="inline-button resolver-button">
+          <i class="fa fa-expand"></i> {{ _('Fullscreen') }}
+        </button>
+        <button id="resolver-change-setup" type="button" class="inline-button resolver-button">
+          {{ _('Setup') }}
+        </button>
+      </div>
+    </div>
+    <p id="resolver-status" class="resolver-status" aria-live="polite"></p>
+    <aside id="resolver-hud" class="resolver-hud" aria-label="{{ _('Operator HUD') }}">
+      <span><strong>{{ _('Mode') }}:</strong> <span id="resolver-hud-mode"></span></span>
+      <span><strong>{{ _('Target') }}:</strong> <span id="resolver-hud-target"></span></span>
+      <span><strong>{{ _('History') }}:</strong> <span id="resolver-hud-history"></span></span>
+      <span><strong>{{ _('Award') }}:</strong> <span id="resolver-hud-award"></span></span>
+      <span><strong>{{ _('Seed') }}:</strong> <code id="resolver-hud-seed"></code></span>
+    </aside>
+
+    <div class="resolver-table-wrap">
+      <table id="ranking-table" class="resolver-table users-table table striped">
+        <thead id="resolver-table-head"></thead>
+        <tbody id="resolver-table-body"></tbody>
+        <tfoot id="resolver-table-foot"></tfoot>
+      </table>
+    </div>
+
+    <div class="resolver-legend" aria-label="{{ _('Cell legend') }}">
+      <span class="resolver-legend__item"
+        ><span class="resolver-legend__swatch resolver-legend__swatch--pending"></span>{{
+        _('Pending') }}</span
+      >
+      <span class="resolver-legend__item"
+        ><span class="resolver-legend__swatch resolver-legend__swatch--solved"></span>{{ _('Solved')
+        }}</span
+      >
+      <span class="resolver-legend__item"
+        ><span class="resolver-legend__swatch resolver-legend__swatch--partial"></span>{{
+        _('Partial') }}</span
+      >
+      <span class="resolver-legend__item"
+        ><span class="resolver-legend__swatch resolver-legend__swatch--failed"></span>{{ _('Failed')
+        }}</span
+      >
+      <span class="resolver-legend__item"
+        >★ {{ _('First solve from current revealed state') }}</span
+      >
+    </div>
+  </section>
+  <div id="resolver-shortcuts" class="resolver-overlay" hidden>
+    <section
+      class="resolver-shortcuts"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="resolver-shortcuts-heading"
+    >
+      <div class="resolver-shortcuts__heading">
+        <h3 id="resolver-shortcuts-heading">{{ _('Resolver shortcuts') }}</h3>
+        <button
+          id="resolver-shortcuts-close"
+          type="button"
+          class="inline-button resolver-button"
+          aria-label="{{ _('Close shortcuts') }}"
+        >
+          ×
+        </button>
+      </div>
+      <dl class="resolver-shortcuts__list">
+        <dt>Space</dt>
+        <dd>{{ _('Step, pause, or resume after a ceremony beat') }}</dd>
+        <dt>P</dt>
+        <dd>{{ _('Play or pause autoplay') }}</dd>
+        <dt>[ / ]</dt>
+        <dd>{{ _('Slow down or speed up') }}</dd>
+        <dt>1–4</dt>
+        <dd>{{ _('Choose a speed preset') }}</dd>
+        <dt>← / Backspace</dt>
+        <dd>{{ _('Back') }}</dd>
+        <dt>→</dt>
+        <dd>{{ _('Forward, or reveal next') }}</dd>
+        <dt>H</dt>
+        <dd>{{ _('Show or hide operator HUD') }}</dd>
+        <dt>F</dt>
+        <dd>{{ _('Toggle fullscreen') }}</dd>
+        <dt>? / /</dt>
+        <dd>{{ _('Show this help') }}</dd>
+        <dt>Esc</dt>
+        <dd>{{ _('Close help or leave fullscreen') }}</dd>
+      </dl>
+    </section>
+  </div>
+  <p id="resolver-client-error" class="resolver-client-error" role="alert" hidden></p>
+</main>
+{{ resolver_data_script }} {% endif %} {% endblock %}

--- a/templates/contest/spotlight-ranking.html
+++ b/templates/contest/spotlight-ranking.html
@@ -72,14 +72,15 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
         <div class="resolver-field">
           <label for="resolver-policy">{{ _('Reveal order') }}</label>
           <select id="resolver-policy" name="policy">
+            <option value="row-sweep">{{ _('ICPC row sweep') }}</option>
             <option value="bottom-up-sticky">{{ _('Bottom-up sticky') }}</option>
             <option value="by-problem">{{ _('By problem') }}</option>
             <option value="by-contestant">{{ _('By contestant') }}</option>
             <option value="manual">{{ _('Manual only') }}</option>
           </select>
           <span class="resolver-field__help"
-            >{{ _('Bottom-up keeps resolving the selected contestant before choosing a new
-            lowest-ranked target.') }}</span
+            >{{ _('Row sweep stays on the current physical row when a contestant moves upward.')
+            }}</span
           >
         </div>
         <div class="resolver-field">
@@ -89,8 +90,7 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
             <option value="contestant">{{ _('Whole contestant') }}</option>
           </select>
           <span class="resolver-field__help"
-            >{{ _('The eye button reveals a whole contestant; Back still moves one cell at a time.')
-            }}</span
+            >{{ _('Manual name-cell reveals can still resolve a whole contestant.') }}</span
           >
         </div>
         <div class="resolver-field">
@@ -108,8 +108,8 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
           <select id="resolver-speed" name="speed">
             <option value="0">0.5×</option>
             <option value="1" selected>1×</option>
-            <option value="2">1.5×</option>
-            <option value="3">2×</option>
+            <option value="2">2×</option>
+            <option value="3">4×</option>
           </select>
           <span class="resolver-field__help"
             >{{ _('Speed changes the pause between settled reveals; row movement remains 700 ms.')
@@ -118,25 +118,34 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
         </div>
         <div class="resolver-field">
           <label for="resolver-award-places">{{ _('Award places') }}</label>
-          <input id="resolver-award-places" name="award_places" type="number" min="0" value="3" />
+          <input id="resolver-award-places" name="award_places" type="number" min="0" value="6" />
           <span class="resolver-field__help"
-            >{{ _('Use 0 to disable the current-state award-zone highlight.') }}</span
+            >{{ _('Ceremony timing metadata only; it does not recolor ranking rows.') }}</span
+          >
+        </div>
+        <div class="resolver-field">
+          <label for="resolver-single-step-start-rank">{{ _('Single-step starts at rank') }}</label>
+          <input
+            id="resolver-single-step-start-rank"
+            name="single_step_start_rank"
+            type="number"
+            min="0"
+            value="6"
+          />
+          <span class="resolver-field__help"
+            >{{ _('This is a one-based displayed rank; use 0 to keep scoreboard timing throughout.')
+            }}</span
           >
         </div>
         <fieldset class="resolver-field resolver-field--beats">
-          <legend>{{ _('Pause autoplay when') }}</legend>
-          <label><input name="pause_rank" type="checkbox" checked /> {{ _('Rank changes') }}</label>
+          <legend>{{ _('Hard pauses') }}</legend>
           <label
             ><input name="pause_award" type="checkbox" checked /> {{ _('Enters award zone')
             }}</label
           >
           <label
-            ><input name="pause_finished" type="checkbox" checked /> {{ _('Contestant is fully
-            resolved') }}</label
-          >
-          <label
-            ><input name="pause_first_solve" type="checkbox" checked /> {{ _('First solve appears')
-            }}</label
+            ><input name="pause_first_solve" type="checkbox" checked /> {{ _('Authoritative first
+            solve appears') }}</label
           >
         </fieldset>
       </div>
@@ -157,7 +166,7 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
           type="button"
           class="inline-button resolver-button resolver-button--primary"
         >
-          {{ _('Reveal next cell') }}
+          <i class="fa fa-step-forward"></i> {{ _('Forward') }}
         </button>
         <button id="resolver-play" type="button" class="inline-button resolver-button">
           <i class="fa fa-play"></i> {{ _('Play') }}
@@ -185,7 +194,7 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
           <i class="fa fa-step-backward"></i> {{ _('Back') }}
         </button>
         <button id="resolver-forward" type="button" class="inline-button resolver-button">
-          {{ _('Forward') }}
+          <i class="fa fa-forward"></i> {{ _('Fast forward') }}
         </button>
         <button id="resolver-reset" type="button" class="inline-button resolver-button">
           <i class="fa fa-undo"></i> {{ _('Reset') }}
@@ -216,6 +225,16 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
       <span><strong>{{ _('Target') }}:</strong> <span id="resolver-hud-target"></span></span>
       <span><strong>{{ _('History') }}:</strong> <span id="resolver-hud-history"></span></span>
       <span><strong>{{ _('Award') }}:</strong> <span id="resolver-hud-award"></span></span>
+      <span
+        ><strong>{{ _('Current position') }}:</strong>
+        <span id="resolver-hud-current-position"></span
+      ></span>
+      <span
+        ><strong>{{ _('After reveal') }}:</strong> <span id="resolver-hud-after-position"></span
+      ></span>
+      <span><strong>{{ _('Movement') }}:</strong> <span id="resolver-hud-movement"></span></span>
+      <span><strong>{{ _('Timing zone') }}:</strong> <span id="resolver-hud-zone"></span></span>
+      <span><strong>{{ _('Remaining') }}:</strong> <span id="resolver-hud-remaining"></span></span>
       <span><strong>{{ _('Seed') }}:</strong> <code id="resolver-hud-seed"></code></span>
     </aside>
 
@@ -223,7 +242,6 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
       <table id="ranking-table" class="resolver-table users-table table striped">
         <thead id="resolver-table-head"></thead>
         <tbody id="resolver-table-body"></tbody>
-        <tfoot id="resolver-table-foot"></tfoot>
       </table>
     </div>
 
@@ -245,7 +263,7 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
         }}</span
       >
       <span class="resolver-legend__item"
-        >★ {{ _('First solve from current revealed state') }}</span
+        >{{ _('First solve uses authoritative contest result data') }}</span
       >
     </div>
   </section>
@@ -269,7 +287,7 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
       </div>
       <dl class="resolver-shortcuts__list">
         <dt>Space</dt>
-        <dd>{{ _('Step, pause, or resume after a ceremony beat') }}</dd>
+        <dd>{{ _('Forward to the next narrative pause') }}</dd>
         <dt>P</dt>
         <dd>{{ _('Play or pause autoplay') }}</dd>
         <dt>[ / ]</dt>
@@ -279,7 +297,9 @@ contest.format_name == 'icpc' %} {% include "contest/media-icpc-css.html" %} {% 
         <dt>← / Backspace</dt>
         <dd>{{ _('Back') }}</dd>
         <dt>→</dt>
-        <dd>{{ _('Forward, or reveal next') }}</dd>
+        <dd>{{ _('Forward to the next narrative pause') }}</dd>
+        <dt>.</dt>
+        <dd>{{ _('Fast forward to the same pause without narrative delays') }}</dd>
         <dt>H</dt>
         <dd>{{ _('Show or hide operator HUD') }}</dd>
         <dt>F</dt>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Tóm tắt</h2>
<p>PR này thiết kế lại tính năng Spotlight Ranking hiện có thành một <em>Resolver</em> xử lý kết quả contest ở phía client, đồng thời bổ sung ceremony (lễ công bố kết quả) quét theo hàng từ dưới lên theo phong cách ICPC.</p>
<p>Mục tiêu là mang lại cho ban tổ chức contest một cách công bố bảng xếp hạng cuối cùng linh hoạt và kịch tính hơn, trong khi vẫn giữ nguyên ngữ nghĩa tính điểm của từng định dạng contest được hỗ trợ.</p>
<p>Các định dạng hiện được hỗ trợ:</p>
<ul>
<li>Default</li>
<li>VNOJ</li>
<li>ICPC</li>
</ul>
<p>Resolver có thể bắt đầu từ đầu bảng điểm, hoặc từ trạng thái đóng băng (frozen) chính thức của contest ở những định dạng có hỗ trợ.</p>
<hr>
<h2>Những thay đổi</h2>
<h3>Kiến trúc Resolver theo ngữ nghĩa</h3>
<p>Implementation Spotlight cũ phụ thuộc nhiều vào bảng ranking đã được render và các thao tác DOM ở phía client.</p>
<p>PR này thay thế cách tiếp cận đó bằng mô hình Resolver theo ngữ nghĩa:</p>
<pre><code class="language-text">Dữ liệu contest từ Django
        ↓
Resolver payload
        ↓
ResolverSession
        ↓
Format Adapter
        ↓
Trạng thái ranking / reveal
        ↓
Planner + Player
        ↓
Trình bày / animation
</code></pre>
<p>Server chuẩn bị dữ liệu contest một lần duy nhất, sau đó toàn bộ ceremony được thực thi ở phía client mà không cần gọi backend cho mỗi lần công bố kết quả.</p>
<p>Code Resolver mới được tách thành các thành phần:</p>
<ul>
<li>serialize payload của contest;</li>
<li>state/history của Resolver;</li>
<li>format adapter cho Default/VNOJ/ICPC;</li>
<li>ranking;</li>
<li>reveal policy;</li>
<li>lập kế hoạch (planning) ceremony;</li>
<li>playback;</li>
<li>timing;</li>
<li>presentation;</li>
<li>FLIP animation.</li>
</ul>
<hr>
<h3>Hỗ trợ các định dạng contest</h3>
<p><strong>Default</strong></p>
<p>Hỗ trợ công bố toàn bộ kết quả từ một bảng điểm ban đầu bị ẩn hoàn toàn.</p>
<p>Resolver tính lại điểm hiển thị và trạng thái thời gian khi từng kết quả bài được công bố.</p>
<p><strong>VNOJ</strong></p>
<p>Hỗ trợ:</p>
<ul>
<li>công bố toàn bộ từ đầu;</li>
<li>trạng thái bảng điểm đóng băng native;</li>
<li>kết quả pending;</li>
<li>ngữ nghĩa điểm/thời gian/penalty của VNOJ.</li>
</ul>
<p><strong>ICPC</strong></p>
<p>Hỗ trợ:</p>
<ul>
<li>công bố toàn bộ từ đầu;</li>
<li>bảng điểm đóng băng chính thức;</li>
<li>trạng thái pending của từng bài;</li>
<li>kết quả AC/sai;</li>
<li>số lần nộp (tries);</li>
<li>thời điểm giải được bài;</li>
<li>ngữ nghĩa penalty của ICPC.</li>
</ul>
<p>Logic tính điểm riêng của từng định dạng vẫn được cô lập trong format adapter tương ứng của Resolver.</p>
<hr>
<h3>Ceremony quét theo hàng kiểu ICPC</h3>
<p>Commit mới nhất bổ sung reveal policy quét theo hàng lấy cảm hứng từ ICPC Tools.</p>
<p>Resolver xử lý bảng xếp hạng từ dưới lên trên.</p>
<p>Nếu thí sinh đang đứng ở một hàng công bố kết quả và nhảy lên hạng cao hơn, Resolver <strong>không</strong> đi theo thí sinh đó.</p>
<p>Thay vào đó, Resolver vẫn giữ nguyên tại chính hàng vật lý đó và tiếp tục với thí sinh vừa chiếm vị trí này.</p>
<p>Ví dụ:</p>
<pre><code class="language-text">#8  A
#9  B
#10 C   &lt;- hàng hiện tại
</code></pre>
<p>Nếu C công bố kết quả và đổi hạng:</p>
<pre><code class="language-text">C: #10 -&gt; #5
</code></pre>
<p>thì Resolver vẫn ở lại hàng #10 và tiếp tục với thí sinh mới đang chiếm vị trí #10.</p>
<p>C sẽ được xử lý lại sau, khi lượt quét đi tới vị trí mới của C.</p>
<p>Trong phạm vi một thí sinh, các bài chưa resolve được chọn theo thứ tự bài của contest, trừ khi có cấu hình thứ tự bài định sẵn.</p>
<hr>
<h3>Ceremony planner và playback</h3>
<p>Resolver tự động giờ đây dùng các bước trình bày có ngữ nghĩa, thay vì coi mọi lần công bố kết quả là một sự kiện timer giống hệt nhau.</p>
<p>Mô hình bước hiện tại bao gồm các khái niệm như:</p>
<ul>
<li>cuộn tới hàng;</li>
<li>chọn thí sinh;</li>
<li>chọn bài;</li>
<li>công bố kết quả;</li>
<li>kết quả làm thí sinh đổi hạng;</li>
<li>kết quả giữ nguyên hạng;</li>
<li>sai/không cải thiện đáng kể;</li>
<li>bỏ chọn;</li>
<li>delay;</li>
<li>pause.</li>
</ul>
<p>Cách làm này tách bạch giữa:</p>
<p><strong>cái gì cần được công bố</strong></p>
<p>và:</p>
<p><strong>kết quả đó nên được trình bày như thế nào</strong></p>
<p>đồng thời giữ logic tính điểm của contest nằm ngoài player trình bày.</p>
<hr>
<h3>Timing lấy cảm hứng từ ICPC</h3>
<p>Resolver dùng các mức delay khác nhau tùy theo loại sự kiện trong ceremony:</p>

Sự kiện | Delay ở tốc độ 1×
-- | --
Chọn thí sinh | 1.30 s
Chọn bài | 1.00 s
Kết quả làm thí sinh đổi hạng | 2.25 s
Kết quả giữ nguyên hạng | 1.50 s
Sai/không cải thiện đáng kể | 0.85 s
Bỏ chọn | 0.25 s


<p>Các preset tốc độ phát có sẵn:</p>
<ul>
<li>0.5×</li>
<li>1×</li>
<li>2×</li>
<li>4×</li>
</ul>
<hr>
<h3>Điều khiển Resolver</h3>
<p>Resolver hiện hỗ trợ:</p>
<ul>
<li>tua tới điểm pause tiếp theo của ceremony;</li>
<li>autoplay/playback;</li>
<li>chỉnh tốc độ;</li>
<li>lùi/tua ngược;</li>
<li>tua nhanh;</li>
<li>reset;</li>
<li>phát lại;</li>
<li>toàn màn hình;</li>
<li>phím tắt;</li>
<li>HUD cho người điều khiển;</li>
<li>mở thủ công từng ô;</li>
<li>mở toàn bộ kết quả của một thí sinh.</li>
</ul>
<p>Cách tương tác thủ công kiểu Director trước đây vẫn được giữ song song với phần trình bày tự động quét theo hàng.</p>
<hr>
<h3>Tính đúng đắn của ranking</h3>
<p>Ranking của Resolver vẫn dựa trên dữ liệu điểm mang tính ngữ nghĩa của contest, thay vì parse HTML đã render.</p>
<p>Implementation giữ nguyên:</p>
<ul>
<li>score;</li>
<li>cumtime;</li>
<li>tiebreaker;</li>
<li>truất quyền thi đấu (DQ);</li>
<li>các hạng hiển thị bằng nhau khi hòa;</li>
<li>thứ tự chính thức cuối cùng.</li>
</ul>
<p>Payload giờ cũng chứa metadata về thứ tự cuối cùng/thứ tự lúc đóng băng lấy từ nguồn chuẩn, để bảng điểm sau khi resolve xong khớp với ranking thông thường của CHT-OJ.</p>
<hr>
<h3>First Solve</h3>
<p>First Solve không còn được suy ra từ thứ tự các ô tình cờ được mở trong ceremony nữa.</p>
<p>Payload của Resolver giờ chứa thông tin First Solve chuẩn, lấy trực tiếp từ dữ liệu kết quả của contest.</p>
<p>Nhờ vậy, First Solve luôn ổn định bất kể thứ tự công bố.</p>
<hr>
<h3>Hiển thị danh tính trong ranking</h3>
<p>Resolver giờ tuân theo setting <code>rank_display_options</code> sẵn có của contest:</p>
<ul>
<li>Avatar</li>
<li>Logo</li>
<li>Ẩn</li>
</ul>
<p>Resolver cũng serialize các tổ chức đang hiển thị và bám sát hơn cách trình bày ranking thông thường.</p>
<p>Resolver không duy trì một setting hiển thị danh tính riêng.</p>
<hr>
<h3>Phân quyền</h3>
<p>Quyền truy cập trang Resolver được giới hạn cho:</p>
<ul>
<li>người dùng có quyền chỉnh sửa contest; hoặc</li>
<li>người dùng có permission <code>judge.can_view_spotlight</code>.</li>
</ul>
<p>Điều kiện hiển thị tab Spotlight cũng đã được cập nhật để khớp với quy tắc phân quyền của Resolver.</p>
<p>Toàn bộ payload của Resolver được nhúng qua cơ chế <code>json_script</code> của Django thay vì nội suy trực tiếp vào JavaScript một cách không an toàn.</p>
<hr>
<h3>Dữ liệu phát triển / kiểm thử</h3>
<p>Đã bổ sung một command chỉ chạy ở chế độ DEBUG để sinh contest demo thực tế cho Resolver với các định dạng:</p>
<ul>
<li>Default;</li>
<li>VNOJ;</li>
<li>ICPC.</li>
</ul>
<p>Các contest được sinh ra bao gồm những tình huống như:</p>
<ul>
<li>submission trong thời gian đóng băng;</li>
<li>thay đổi thứ hạng;</li>
<li>hòa điểm;</li>
<li>truất quyền thi đấu;</li>
<li>chấm điểm từng phần;</li>
<li>các lần nộp sai.</li>
</ul>
<p>Phần này phục vụ cho việc phát triển và kiểm thử Resolver ở local.</p>
<hr>
<h3>Tests</h3>
<p>PR này bổ sung test coverage cả Python lẫn JavaScript cho hành vi của Resolver, bao gồm:</p>
<ul>
<li>sinh payload;</li>
<li>các định dạng được hỗ trợ;</li>
<li>trạng thái đóng băng;</li>
<li>tính tương đương của ranking;</li>
<li>thứ tự cuối cùng;</li>
<li>First Solve;</li>
<li>các tùy chọn hiển thị hạng;</li>
<li>nhiều tổ chức;</li>
<li>phân quyền Resolver;</li>
<li>việc chọn mục tiêu khi quét theo hàng;</li>
<li>thay đổi thứ hạng;</li>
<li>việc chọn bài;</li>
<li>timing;</li>
<li>playback;</li>
<li>rewind/reset;</li>
<li>các contract của UI Resolver;</li>
<li>contest demo được seed.</li>
</ul>
<hr>
<h3>Các file / khu vực bị ảnh hưởng</h3>
<p>Phần implementation Resolver mới:</p>
<pre><code class="language-text">judge/resolver.py

resources/resolver/
├── animation.js
├── bootstrap.js
├── controller.js
├── core.js
├── formats/
│   ├── default.js
│   ├── icpc.js
│   └── vnoj.js
├── page.js
├── planner.js
├── player.js
├── policies.js
├── presentation.js
├── ranking.js
├── timing.js
├── utils.js
└── tests/
</code></pre>
<p>Ngoài ra còn cập nhật:</p>
<ul>
<li>view của Spotlight ranking;</li>
<li>template của Spotlight ranking;</li>
<li>contest tabs;</li>
<li>phần seed dữ liệu demo cho Resolver;</li>
<li>test Python của Resolver;</li>
<li>các script trong package.</li>
</ul>
<hr>
<h3>Phạm vi</h3>
<p>PR này tập trung vào việc thiết lập kiến trúc Resolver và hành vi ceremony kiểu ICPC mới.</p>
<p>Các phần như đơn giản hóa UX, localization, hardening bảo mật, tương tác mở kết quả hàng loạt và tối ưu hiệu năng có thể được xử lý trong các thay đổi tiếp theo, sau khi implementation này được review.</p></body></html><!--EndFragment-->
</body>
</html>
<img width="1826" height="941" alt="image" src="https://github.com/user-attachments/assets/d49c0f40-cbe2-47cb-85db-56c67702a276" />

